### PR TITLE
#4 Add refresh token support to identity API

### DIFF
--- a/FitBridge_API/Controllers/IdentitiesController.cs
+++ b/FitBridge_API/Controllers/IdentitiesController.cs
@@ -11,6 +11,8 @@ using FitBridge_API.Helpers.RequestHelpers;
 using FitBridge_Application.Dtos.Identities;
 using FitBridge_Application.Features.Identities.Login;
 using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Dtos.Tokens;
+using FitBridge_Application.Features.Identities.Token;
 
 namespace FitBridge_API.Controllers;
 
@@ -64,5 +66,23 @@ public class IdentitiesController(IMediator _mediator, IApplicationUserService _
             return BadRequest(new BaseResponse<string>(StatusCodes.Status400BadRequest.ToString(), ex.Message, null));
         }
         return Ok(new BaseResponse<LoginResponseDTO>(StatusCodes.Status200OK.ToString(), "Login successful", response));
+    }
+
+    [HttpPost("refresh-token")]
+    [AllowAnonymous]
+    public async Task<ActionResult<RefreshTokenResponse>> RefreshToken([FromBody] RefreshTokenCommand refreshToken) 
+    {
+        try
+        {
+            var result = await _mediator.Send(refreshToken);
+            return Ok(new BaseResponse<RefreshTokenResponse>(StatusCodes.Status200OK.ToString(), "Token refreshed successfully", result));
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new BaseResponse<string>(
+            StatusCodes.Status400BadRequest.ToString(),
+            ex.Message,
+            null));
+        }
     }
 }

--- a/FitBridge_Application/Dtos/Tokens/RefreshTokenRequest.cs
+++ b/FitBridge_Application/Dtos/Tokens/RefreshTokenRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FitBridge_Application.Dtos.Tokens
+{
+    public class RefreshTokenRequest
+    {
+        public string RefreshToken { get; set; }
+    }
+}

--- a/FitBridge_Application/Dtos/Tokens/RefreshTokenResponse.cs
+++ b/FitBridge_Application/Dtos/Tokens/RefreshTokenResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FitBridge_Application.Dtos.Tokens
+{
+    public class RefreshTokenResponse
+    {
+        public string AccessToken { get; set; } = string.Empty;
+        public string IdToken { get; set; } = string.Empty;
+        public string RefreshToken { get; set; } = string.Empty;
+    }
+}

--- a/FitBridge_Application/Features/Identities/Token/RefreshTokenCommand.cs
+++ b/FitBridge_Application/Features/Identities/Token/RefreshTokenCommand.cs
@@ -1,0 +1,15 @@
+﻿using FitBridge_Application.Dtos.Tokens;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FitBridge_Application.Features.Identities.Token
+{
+    public class RefreshTokenCommand : IRequest<RefreshTokenResponse>
+    {
+        public string RefreshToken { get; set; } = string.Empty;
+    }
+}

--- a/FitBridge_Application/Features/Identities/Token/RefreshTokenCommandHandler.cs
+++ b/FitBridge_Application/Features/Identities/Token/RefreshTokenCommandHandler.cs
@@ -1,0 +1,53 @@
+﻿using FitBridge_Application.Dtos.Tokens;
+using FitBridge_Application.Interfaces.Services;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FitBridge_Application.Features.Identities.Token
+{
+    public class RefreshTokenCommandHandler(IUserTokenService userTokenService, IApplicationUserService applicationUserService) : IRequestHandler<RefreshTokenCommand, RefreshTokenResponse>
+    {
+
+        public async Task<RefreshTokenResponse> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var userId = await userTokenService.ValidateRefreshToken(request.RefreshToken);
+                if(userId == null)
+                {
+                    throw new UnauthorizedAccessException("Invalid refresh token");
+                }
+
+                var user = await applicationUserService.GetByIdAsync(Guid.Parse(userId));
+
+                if(user == null)
+                {
+                    throw new UnauthorizedAccessException("User not found");
+                }
+
+                var userRoles = await applicationUserService.GetUserRolesAsync(user);
+
+                var newAccessToken = userTokenService.CreateAccessToken(user, userRoles);
+                var newIdToken = userTokenService.CreateIdToken(user, userRoles);
+                var newRefreshToken = userTokenService.CreateRefreshToken(user);
+
+                user.RefreshToken = newRefreshToken;
+                await applicationUserService.UpdateAsync(user);
+
+                return new RefreshTokenResponse
+                {
+                    AccessToken = newAccessToken,
+                    IdToken = newIdToken,
+                    RefreshToken = newRefreshToken
+                };
+            } catch (Exception e)
+            {
+                throw new UnauthorizedAccessException("Could not refresh token: ", e);
+            }
+        }
+    }
+}

--- a/FitBridge_Application/Interfaces/Services/IUserTokenService.cs
+++ b/FitBridge_Application/Interfaces/Services/IUserTokenService.cs
@@ -6,32 +6,33 @@ namespace FitBridge_Application.Interfaces.Services;
 public interface IUserTokenService
 {
     /// <summary>
-        /// Creates an ID token for the specified user with their role.
-        /// </summary>
-        /// <param name="user">The application user.</param>
-        /// <param name="role">The user's role.</param>
-        /// <returns>A string representing the ID token.</returns>
-        string CreateIdToken(ApplicationUser user, List<string> roles);
+    /// Creates an ID token for the specified user with their role.
+    /// </summary>
+    /// <param name="user">The application user.</param>
+    /// <param name="role">The user's role.</param>
+    /// <returns>A string representing the ID token.</returns>
+    string CreateIdToken(ApplicationUser user, List<string> roles);
 
-        /// <summary>
-        /// Creates an access token for the specified user with their role.
-        /// </summary>
-        /// <param name="user">The application user.</param>
-        /// <param name="role">The user's role.</param>
-        /// <returns>A string representing the access token.</returns>
-        string CreateAccessToken(ApplicationUser user, List<string> roles);
+    /// <summary>
+    /// Creates an access token for the specified user with their role.
+    /// </summary>
+    /// <param name="user">The application user.</param>
+    /// <param name="role">The user's role.</param>
+    /// <returns>A string representing the access token.</returns>
+    string CreateAccessToken(ApplicationUser user, List<string> roles);
 
-        /// <summary>
-        /// Creates a refresh token for the specified user.
-        /// </summary>
-        /// <param name="user">The application user.</param>
-        /// <returns>A string representing the refresh token.</returns>
-        string CreateRefreshToken(ApplicationUser user);
+    /// <summary>
+    /// Creates a refresh token for the specified user.
+    /// </summary>
+    /// <param name="user">The application user.</param>
+    /// <returns>A string representing the refresh token.</returns>
+    string CreateRefreshToken(ApplicationUser user);
 
-        /// <summary>
-        /// Revokes refresh token for the specified user.
-        /// </summary>
-        /// <param name="userId">The ID of the user whose tokens should be revoked.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        Task RevokeUserToken(string userId);
+    /// <summary>
+    /// Revokes refresh token for the specified user.
+    /// </summary>
+    /// <param name="userId">The ID of the user whose tokens should be revoked.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task RevokeUserToken(string userId);
+    Task<string?> ValidateRefreshToken(string refreshToken);
 }


### PR DESCRIPTION
Introduces refresh token request/response DTOs, command and handler for token refresh, and exposes a new /refresh-token endpoint in IdentitiesController. Updates IUserTokenService and UserTokenService to support refresh token validation, enabling secure token renewal for authenticated users.