### PR TITLE
Refactor gym image handling to use GymImageDto

### DIFF
--- a/FitBridge_Application/Dtos/Gym/GetAllGymsDto.cs
+++ b/FitBridge_Application/Dtos/Gym/GetAllGymsDto.cs
@@ -12,7 +12,7 @@
 
         public string GymAddress { get; set; } = string.Empty;
 
-        public List<string> GymImages { get; set; } = [];
+        public List<GymImageDto> GymImages { get; set; } = [];
 
         public double Longitude { get; set; } = 0.0;
 

--- a/FitBridge_Application/Dtos/Gym/GetGymDetailsDto.cs
+++ b/FitBridge_Application/Dtos/Gym/GetGymDetailsDto.cs
@@ -10,7 +10,7 @@
 
         public string GymAddress { get; set; } = string.Empty;
 
-        public List<string> GymImages { get; set; } = [];
+        public List<GymImageDto> GymImages { get; set; } = [];
 
         public double Longitude { get; set; } = 0.0;
 

--- a/FitBridge_Application/Dtos/Gym/GymImageDto.cs
+++ b/FitBridge_Application/Dtos/Gym/GymImageDto.cs
@@ -1,0 +1,7 @@
+﻿namespace FitBridge_Application.Dtos.Gym
+{
+    public class GymImageDto
+    {
+        public string Url { get; set; } = string.Empty;
+    }
+}

--- a/FitBridge_Application/MappingProfiles/GymMappingProfiles.cs
+++ b/FitBridge_Application/MappingProfiles/GymMappingProfiles.cs
@@ -11,12 +11,16 @@ namespace FitBridge_Application.MappingProfiles
             CreateProjection<ApplicationUser, GetGymDetailsDto>()
                 .ForMember(dest => dest.Dob, opt => opt.MapFrom(
                     src => new DateOnly(src.Dob.Year, src.Dob.Month, src.Dob.Day)))
+                .ForMember(dest => dest.GymImages, opt => opt.MapFrom(
+                    src => src.GymImages.Select(gi => new GymImageDto { Url = gi }).ToList()))
                 .ForMember(dest => dest.RepresentName, opt => opt.MapFrom(
                     src => src.FullName));
 
             CreateProjection<ApplicationUser, GetAllGymsDto>()
                 .ForMember(dest => dest.Dob, opt => opt.MapFrom(
                     src => new DateOnly(src.Dob.Year, src.Dob.Month, src.Dob.Day)))
+                .ForMember(dest => dest.GymImages, opt => opt.MapFrom(
+                    src => src.GymImages.Select(gi => new GymImageDto { Url = gi }).ToList()))
                 .ForMember(dest => dest.RepresentName, opt => opt.MapFrom(
                     src => src.FullName));
         }


### PR DESCRIPTION
Replaced List<string> GymImages with List<GymImageDto> in GetAllGymsDto and GetGymDetailsDto for improved type safety and extensibility. Added GymImageDto class and updated GymMappingProfiles to map gym images to the new DTO.
