### PR TITLE
#31 Add payment cancellation feature

### DIFF
--- a/FitBridge_API/Controllers/PaymentsController.cs
+++ b/FitBridge_API/Controllers/PaymentsController.cs
@@ -1,5 +1,6 @@
 using FitBridge_API.Helpers.RequestHelpers;
 using FitBridge_Application.Dtos.Payments;
+using FitBridge_Application.Features.Payments.CancelPaymentCommand;
 using FitBridge_Application.Features.Payments.CreatePaymentLink;
 using FitBridge_Application.Features.Payments.GetPaymentInfor;
 using FitBridge_Application.Features.Payments.PaymentCallbackWebhook;
@@ -32,6 +33,8 @@ public class PaymentsController(IMediator _mediator) : _BaseApiController
             return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Webhook processed successfully", result));
         }
 
+        //return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Webhook processed successfully", true));
+
         return BadRequest(new BaseResponse<bool>(StatusCodes.Status400BadRequest.ToString(), "Failed to process webhook", result));
     }
 
@@ -41,5 +44,13 @@ public class PaymentsController(IMediator _mediator) : _BaseApiController
     {
         var result = await _mediator.Send(new GetPaymentInfoCommand { Id = id });
         return Ok(new BaseResponse<PaymentInfoResponseDto>(StatusCodes.Status200OK.ToString(), "Payment information retrieved successfully", result));
+    }
+
+    [HttpPost("cancel")]
+    [Authorize]
+    public async Task<IActionResult> CancelPayment([FromBody] CancelPaymentCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Payment cancelled successfully", result));
     }
 }

--- a/FitBridge_Application/Features/Payments/CancelPaymentCommand/CancelPaymentCommand.cs
+++ b/FitBridge_Application/Features/Payments/CancelPaymentCommand/CancelPaymentCommand.cs
@@ -1,0 +1,9 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.Payments.CancelPaymentCommand;
+
+public class CancelPaymentCommand : IRequest<bool>
+{
+    public long OrderCode { get; set; }
+}

--- a/FitBridge_Application/Features/Payments/CancelPaymentCommand/CancelPaymentCommandHandler.cs
+++ b/FitBridge_Application/Features/Payments/CancelPaymentCommand/CancelPaymentCommandHandler.cs
@@ -1,0 +1,25 @@
+using System;
+using MediatR;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Application.Specifications.Transactions;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Enums.Orders;
+
+namespace FitBridge_Application.Features.Payments.CancelPaymentCommand;
+
+public class CancelPaymentCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<CancelPaymentCommand, bool>
+{
+    public async Task<bool> Handle(CancelPaymentCommand request, CancellationToken cancellationToken)
+    {
+        var transactionEntity = await _unitOfWork.Repository<Transaction>().GetBySpecificationAsync(new GetTransactionByOrderCodeSpec(request.OrderCode, true), false);
+        if (transactionEntity == null)
+        {
+            throw new NotFoundException("Transaction not found");
+        }
+        transactionEntity.Order.Status = OrderStatus.Cancelled;
+        transactionEntity.Status = TransactionStatus.Failed;
+        await _unitOfWork.CommitAsync();
+        return true;
+    }
+}

--- a/FitBridge_Application/Specifications/Transactions/GetTransactionByOrderCodeSpec.cs
+++ b/FitBridge_Application/Specifications/Transactions/GetTransactionByOrderCodeSpec.cs
@@ -6,7 +6,8 @@ namespace FitBridge_Application.Specifications.Transactions;
 
 public class GetTransactionByOrderCodeSpec : BaseSpecification<Transaction>
 {
-    public GetTransactionByOrderCodeSpec(long orderCode) : base(x => x.OrderCode == orderCode && x.IsEnabled == true)
+    public GetTransactionByOrderCodeSpec(long orderCode, bool isInclude = false) : base(x => x.OrderCode == orderCode && x.IsEnabled == true)
     {
+        AddInclude(x => x.Order);
     }
 }

--- a/FitBridge_Domain/Enums/Payments/PaymentInfoStatus.cs
+++ b/FitBridge_Domain/Enums/Payments/PaymentInfoStatus.cs
@@ -1,0 +1,6 @@
+namespace FitBridge_Domain.Enums.Payments;
+
+public enum PaymentInfoStatus
+{
+    EXPIRED, PENDING, CANCELLED, PAID
+}

--- a/FitBridge_Infrastructure/Services/PayOSService.cs
+++ b/FitBridge_Infrastructure/Services/PayOSService.cs
@@ -17,6 +17,7 @@ using Net.payOS.Types;
 using FitBridge_Domain.Entities.Gyms;
 using FitBridge_Application.Specifications.GymCoursePts.GetGymCoursePtById;
 using FitBridge_Application.Specifications.Transactions;
+using FitBridge_Domain.Enums.Payments;
 
 namespace FitBridge_Infrastructure.Services;
 
@@ -197,6 +198,10 @@ public class PayOSService : IPayOSService
             {
                 _logger.LogWarning("Failed to verify webhook data");
                 return false;
+            }
+            if(verifiedWebhookData.orderCode == 123)
+            {
+                 return true; // Test webhook from PayOS
             }
             
             var transaction = await _unitOfWork.Repository<FitBridge_Domain.Entities.Orders.Transaction>().GetBySpecificationAsync(new GetTransactionByOrderCodeSpec(verifiedWebhookData.orderCode));


### PR DESCRIPTION
Introduced CancelPaymentCommand and handler to allow cancelling payments via API. Updated PaymentsController with a new endpoint for cancellation, modified transaction specification to include order, and added PaymentInfoStatus enum. Also added a test webhook bypass in PayOSService.