### PR TITLE
#57 Add freelance PT package retrieval for customer purchases

### DIFF
--- a/FitBridge_API/Controllers/CustomerPurchasedController.cs
+++ b/FitBridge_API/Controllers/CustomerPurchasedController.cs
@@ -4,6 +4,7 @@ using FitBridge_API.Helpers.RequestHelpers;
 using FitBridge_Application.Dtos.CustomerPurchaseds;
 using FitBridge_Application.Dtos.GymCourses;
 using FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchased;
+using FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchasedFreelancePt;
 using FitBridge_Application.Features.GymCourses.GetPurchasedGymCoursePtForSchedule;
 using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByCustomerId;
 using FitBridge_Application.Specifications.GymCoursePts.GetPurchasedGymCoursePtForScheduleGetPurchasedGymCoursePtForSchedule;
@@ -21,11 +22,19 @@ public class CustomerPurchasedController(IMediator _mediator) : _BaseApiControll
         var pagination = ResultWithPagination(response.Items, response.Total, parameters.Page, parameters.Size);
         return Ok(new BaseResponse<Pagination<GymCoursesPtResponse>>(StatusCodes.Status200OK.ToString(), "Get purchased gym course pt for schedule success", pagination));
     }
-    [HttpGet]
-    public async Task<IActionResult> GetCustomerPurchased([FromQuery] GetCustomerPurchasedParams parameters)
+    [HttpGet("customer-package/gym-course")]
+    public async Task<IActionResult> GetCustomerPurchasedGymCourse([FromQuery] GetCustomerPurchasedParams parameters)
     {
         var response = await _mediator.Send(new GetCustomerPurchasedQuery { Params = parameters });
         var pagination = ResultWithPagination(response.Items, response.Total, parameters.Page, parameters.Size);
-        return Ok(new BaseResponse<Pagination<CustomerPurchasedResponseDto>>(StatusCodes.Status200OK.ToString(), "Get customer purchased success", pagination));
+        return Ok(new BaseResponse<Pagination<CustomerPurchasedResponseDto>>(StatusCodes.Status200OK.ToString(), "Get customer purchased course success", pagination));
+    }
+
+    [HttpGet("customer-package/freelance-pt")]
+    public async Task<IActionResult> GetCustomerPurchasedFreelancePt([FromQuery] GetCustomerPurchasedParams parameters)
+    {
+        var response = await _mediator.Send(new GetCustomerPurchasedFreelancePtQuery { Params = parameters });
+        var pagination = ResultWithPagination(response.Items, response.Total, parameters.Page, parameters.Size);
+        return Ok(new BaseResponse<Pagination<CustomerPurchasedFreelancePtResponseDto>>(StatusCodes.Status200OK.ToString(), "Get customer purchased freelance pt success", pagination));
     }
 }

--- a/FitBridge_Application/Dtos/CustomerPurchaseds/CustomerPurchasedFreelancePtResponseDto.cs
+++ b/FitBridge_Application/Dtos/CustomerPurchaseds/CustomerPurchasedFreelancePtResponseDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace FitBridge_Application.Dtos.CustomerPurchaseds;
+
+public class CustomerPurchasedFreelancePtResponseDto
+{
+    public Guid Id { get; set; }
+    public string PackageName { get; set; } = string.Empty;
+    public string CourseImageUrl { get; set; } = string.Empty;
+    public int AvailableSessions { get; set; }
+    public DateOnly ExpirationDate { get; set; }
+    public Guid? FreelancePTPackageId { get; set; }
+}

--- a/FitBridge_Application/Dtos/CustomerPurchaseds/CustomerPurchasedResponseDto.cs
+++ b/FitBridge_Application/Dtos/CustomerPurchaseds/CustomerPurchasedResponseDto.cs
@@ -5,20 +5,18 @@ namespace FitBridge_Application.Dtos.CustomerPurchaseds;
 
 public class CustomerPurchasedResponseDto
 {
-public Guid Id { get; set; }
+    public Guid Id { get; set; }
 
-// Package Information
-public string PackageName { get; set; } = string.Empty;
-public string CourseImageUrl { get; set; } = string.Empty;
+    // Package Information
+    public string PackageName { get; set; } = string.Empty;
+    public string CourseImageUrl { get; set; } = string.Empty;
 
-public int AvailableSessions { get; set; }
-public DateOnly ExpirationDate { get; set; }
-public bool CanAssignPT { get; set; }
-public decimal PTAssignmentPrice { get; set; }
+    public int AvailableSessions { get; set; }
+    public DateOnly ExpirationDate { get; set; }
+    public bool CanAssignPT { get; set; }
+    public decimal PTAssignmentPrice { get; set; }
 
-// PT Information (if assigned)
-public ICollection<GymCoursePtDto>? PtList { get; set; }
-public Guid? GymCourseId { get; set; }
-public Guid? FreelancePTPackageId { get; set; }
-
+    // PT Information (if assigned)
+    public ICollection<GymCoursePtDto>? PtList { get; set; }
+    public Guid? GymCourseId { get; set; }
 }

--- a/FitBridge_Application/Features/CustomerPurchaseds/GetCustomerPurchased/GetCustomerPurchasedQueryHandler.cs
+++ b/FitBridge_Application/Features/CustomerPurchaseds/GetCustomerPurchased/GetCustomerPurchasedQueryHandler.cs
@@ -8,16 +8,24 @@ using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Domain.Entities.Gyms;
 using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByCustomerId;
 using AutoMapper;
-
+using FitBridge_Application.Interfaces.Services;
+using Microsoft.AspNetCore.Http;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Application.Interfaces.Utils;
 namespace FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchased;
 
-public class GetCustomerPurchasedQueryHandler(IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<GetCustomerPurchasedQuery, PagingResultDto<CustomerPurchasedResponseDto>>
+public class GetCustomerPurchasedQueryHandler(IUnitOfWork _unitOfWork, IMapper _mapper, IUserUtil _userUtil, IHttpContextAccessor _httpContextAccessor) : IRequestHandler<GetCustomerPurchasedQuery, PagingResultDto<CustomerPurchasedResponseDto>>
 {
     public async Task<PagingResultDto<CustomerPurchasedResponseDto>> Handle(GetCustomerPurchasedQuery request, CancellationToken cancellationToken)
     {
-        var customerPurchaseds = await _unitOfWork.Repository<CustomerPurchased>().GetAllWithSpecificationProjectedAsync<CustomerPurchasedResponseDto>(new GetCustomerPurchasedByCustomerIdSpec(request.Params.CustomerId), _mapper.ConfigurationProvider);
+        var userId = _userUtil.GetAccountId(_httpContextAccessor.HttpContext);
+        if (userId == null)
+        {
+            throw new NotFoundException("User not found");
+        }
+        var customerPurchaseds = await _unitOfWork.Repository<CustomerPurchased>().GetAllWithSpecificationProjectedAsync<CustomerPurchasedResponseDto>(new GetCustomerPurchasedByCustomerIdSpec(userId.Value, request.Params), _mapper.ConfigurationProvider);
 
-        var totalItems = await _unitOfWork.Repository<CustomerPurchased>().CountAsync(new GetCustomerPurchasedByCustomerIdSpec(request.Params.CustomerId));
+        var totalItems = await _unitOfWork.Repository<CustomerPurchased>().CountAsync(new GetCustomerPurchasedByCustomerIdSpec(userId.Value, request.Params));
         
         return new PagingResultDto<CustomerPurchasedResponseDto>(totalItems, customerPurchaseds);
     }

--- a/FitBridge_Application/Features/CustomerPurchaseds/GetCustomerPurchasedFreelancePt/GetCustomerPurchasedFreelancePtQuery.cs
+++ b/FitBridge_Application/Features/CustomerPurchaseds/GetCustomerPurchasedFreelancePt/GetCustomerPurchasedFreelancePtQuery.cs
@@ -1,0 +1,12 @@
+using System;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.CustomerPurchaseds;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByCustomerId;
+using MediatR;
+
+namespace FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchasedFreelancePt;
+
+public class GetCustomerPurchasedFreelancePtQuery : IRequest<PagingResultDto<CustomerPurchasedFreelancePtResponseDto>>
+{
+    public GetCustomerPurchasedParams Params { get; set; }
+}

--- a/FitBridge_Application/Features/CustomerPurchaseds/GetCustomerPurchasedFreelancePt/GetCustomerPurchasedFreelancePtQueryHandler.cs
+++ b/FitBridge_Application/Features/CustomerPurchaseds/GetCustomerPurchasedFreelancePt/GetCustomerPurchasedFreelancePtQueryHandler.cs
@@ -1,0 +1,33 @@
+using System;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.CustomerPurchaseds;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Interfaces.Utils;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByCustomerId;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Exceptions;
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using MediatR;
+using FitBridge_Domain.Entities.Gyms;
+
+namespace FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchasedFreelancePt;
+
+public class GetCustomerPurchasedFreelancePtQueryHandler(IUnitOfWork _unitOfWork, IMapper _mapper, IUserUtil _userUtil, IHttpContextAccessor _httpContextAccessor) : IRequestHandler<GetCustomerPurchasedFreelancePtQuery, PagingResultDto<CustomerPurchasedFreelancePtResponseDto>>
+{
+    public async Task<PagingResultDto<CustomerPurchasedFreelancePtResponseDto>> Handle(GetCustomerPurchasedFreelancePtQuery request, CancellationToken cancellationToken)
+    {
+        var userId = _userUtil.GetAccountId(_httpContextAccessor.HttpContext);
+        if (userId == null)
+        {
+            throw new NotFoundException("User not found");
+        }
+        var customerPurchaseds = await _unitOfWork.Repository<CustomerPurchased>().GetAllWithSpecificationProjectedAsync<CustomerPurchasedFreelancePtResponseDto>(new GetCustomerPurchasedByCustomerIdSpec(userId.Value, request.Params, false), _mapper.ConfigurationProvider);
+
+        var totalItems = await _unitOfWork.Repository<CustomerPurchased>().CountAsync(new GetCustomerPurchasedByCustomerIdSpec(userId.Value, request.Params, false));
+        
+        return new PagingResultDto<CustomerPurchasedFreelancePtResponseDto>(totalItems, customerPurchaseds);
+    }
+
+}

--- a/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
@@ -32,6 +32,15 @@ public class CustomerPurchasedMappingProfile : Profile
             .ForMember(dest => dest.PTAssignmentPrice, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.PtPrice))
             .ForMember(dest => dest.PtList, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.GymCoursePTs))
             .ForMember(dest => dest.GymCourseId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId))
-            .ForMember(dest => dest.FreelancePTPackageId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackageId));
+            ;
+
+        CreateProjection<CustomerPurchased, CustomerPurchasedFreelancePtResponseDto>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.PackageName, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackage.Name))
+            .ForMember(dest => dest.CourseImageUrl, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackage.ImageUrl))
+            .ForMember(dest => dest.AvailableSessions, opt => opt.MapFrom(src => src.AvailableSessions))
+            .ForMember(dest => dest.ExpirationDate, opt => opt.MapFrom(src => src.ExpirationDate))
+            .ForMember(dest => dest.FreelancePTPackageId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackageId))
+            ;
     }
 }

--- a/FitBridge_Application/Specifications/CustomerPurchaseds/GetCustomerPurchasedByCustomerId/GetCustomerPurchasedByCustomerIdSpec.cs
+++ b/FitBridge_Application/Specifications/CustomerPurchaseds/GetCustomerPurchasedByCustomerId/GetCustomerPurchasedByCustomerIdSpec.cs
@@ -6,10 +6,20 @@ namespace FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPur
 
 public class GetCustomerPurchasedByCustomerIdSpec : BaseSpecification<CustomerPurchased>
 {
-    public GetCustomerPurchasedByCustomerIdSpec(Guid accountId) : base(x => x.CustomerId == accountId)
+    public GetCustomerPurchasedByCustomerIdSpec(Guid accountId, GetCustomerPurchasedParams parameters, bool isGymCourse = true) : base(x => x.CustomerId == accountId && x.IsEnabled
+    && x.OrderItems.Any(x => isGymCourse ? x.GymCourseId != null : x.FreelancePTPackageId != null))
     {
         AddInclude(x => x.OrderItems);
-        AddInclude("OrderItems.GymCourse");
-        AddInclude("OrderItems.GymCourse.GymCoursePts");
+        if (isGymCourse)
+        {
+            AddInclude("OrderItems.GymCourse");
+            AddInclude("OrderItems.GymCourse.GymCoursePTs");
+        }
+        else
+        {
+            AddInclude("OrderItems.FreelancePTPackage");
+        }
+        AddOrderByDesc(x => x.ExpirationDate);
+        AddPaging((parameters.Page - 1) * parameters.Size, parameters.Size);
     }
 }

--- a/FitBridge_Application/Specifications/CustomerPurchaseds/GetCustomerPurchasedByCustomerId/GetCustomerPurchasedParams.cs
+++ b/FitBridge_Application/Specifications/CustomerPurchaseds/GetCustomerPurchasedByCustomerId/GetCustomerPurchasedParams.cs
@@ -3,5 +3,4 @@ namespace FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPur
 
 public class GetCustomerPurchasedParams : BaseParams
 {
-    public Guid CustomerId { get; set; }
 }


### PR DESCRIPTION
Introduced endpoints, DTOs, handlers, and mapping for fetching customer-purchased freelance PT packages separately from gym course packages. Updated specifications and removed CustomerId from request parameters to use authenticated user context. This refactor improves separation of gym course and freelance PT package queries and aligns with new business requirements.