### PR TITLE
#72 Refactor PTSlots property and mapping in GetPTSlot

### DIFF
--- a/FitBridge_Application/Dtos/GymSlots/GetPTSlot.cs
+++ b/FitBridge_Application/Dtos/GymSlots/GetPTSlot.cs
@@ -10,5 +10,5 @@ public class GetPTSlot
     public TimeOnly? StartTime { get; set; }
     public TimeOnly? EndTime { get; set; }
     public bool? IsActivated { get; set; }
-    public List<GetPTSlotResponse>? PTSlots { get; set; }
+    public GetPTSlotResponse PTSlots { get; set; }
 }

--- a/FitBridge_Application/Features/GymSlots/GetAllPtSlot/GetAllPtSlotsQueryHandler.cs
+++ b/FitBridge_Application/Features/GymSlots/GetAllPtSlot/GetAllPtSlotsQueryHandler.cs
@@ -18,14 +18,15 @@ public class GetAllPtSlotsQueryHandler(IUnitOfWork _unitOfWork, IApplicationUser
     {
         var ptEntity = await _applicationUserService.GetByIdAsync(request.Params.PtId);
         var ptGymSlots = await _unitOfWork.Repository<GymSlot>().GetAllWithSpecificationAsync(new GetGymSlotForPtRegisterSpec(ptEntity.GymOwnerId.Value, request.Params));
-        
+        var ptGymSlotDtos = new List<GetPTSlot>();
         foreach (var ptGymSlot in ptGymSlots)
         {
             ptGymSlot.PTGymSlots = ptGymSlot.PTGymSlots.Where(x => x.PTId == request.Params.PtId && x.RegisterDate == request.Params.RegisterDate).ToList();
+            ptGymSlotDtos.Add(_mapper.Map<GetPTSlot>(ptGymSlot));
+            ptGymSlotDtos.Last().PTSlots = _mapper.Map<GetPTSlotResponse>(ptGymSlot.PTGymSlots.FirstOrDefault());
         }
-        var ptGymSlotsDto = _mapper.Map<List<GetPTSlot>>(ptGymSlots);
 
         var totalItems = await _unitOfWork.Repository<GymSlot>().CountAsync(new GetGymSlotForPtRegisterSpec(ptEntity.GymOwnerId.Value, request.Params));
-        return new PagingResultDto<GetPTSlot>(totalItems, ptGymSlotsDto);
+        return new PagingResultDto<GetPTSlot>(totalItems, ptGymSlotDtos);
     }
 }

--- a/FitBridge_Application/MappingProfiles/GymSlotMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/GymSlotMappingProfile.cs
@@ -19,7 +19,6 @@ public class GymSlotMappingProfile : Profile
         .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
         .ForMember(dest => dest.StartTime, opt => opt.MapFrom(src => src.StartTime))
         .ForMember(dest => dest.EndTime, opt => opt.MapFrom(src => src.EndTime))
-        .ForMember(dest => dest.IsActivated, opt => opt.MapFrom(src => src.PTGymSlots.Any()))
-        .ForMember(dest => dest.PTSlots, opt => opt.MapFrom(src => src.PTGymSlots));
+        .ForMember(dest => dest.IsActivated, opt => opt.MapFrom(src => src.PTGymSlots.Any()));
     }
 }


### PR DESCRIPTION
Changed GetPTSlot.PTSlots from a list to a single GetPTSlotResponse and updated the query handler to map accordingly. Adjusted GymSlotMappingProfile to remove mapping for PTSlots and ensure IsActivated is set based on PTGymSlots presence.