### PR TITLE
#72 Add PT details and slot name to booking responses

### DIFF
--- a/FitBridge_Application/Dtos/Bookings/GetCustomerBookingsResponse.cs
+++ b/FitBridge_Application/Dtos/Bookings/GetCustomerBookingsResponse.cs
@@ -6,6 +6,7 @@ namespace FitBridge_Application.Dtos.Bookings;
 public class GetCustomerBookingsResponse
 {
     public Guid BookingId { get; set; }
+    public string? SlotName { get; set; }
     public DateOnly BookingDate { get; set; }
 
     public TimeOnly? PtFreelanceStartTime { get; set; }
@@ -20,6 +21,8 @@ public class GetCustomerBookingsResponse
     public Guid CustomerPurchasedId { get; set; }
 
     public SessionStatus SessionStatus { get; set; }
+    public string? PtName { get; set; }
+    public string? PtAvatarUrl { get; set; }
 
     public string? Note { get; set; }
 

--- a/FitBridge_Application/Dtos/GymCourses/GymCoursesPtResponse.cs
+++ b/FitBridge_Application/Dtos/GymCourses/GymCoursesPtResponse.cs
@@ -6,6 +6,7 @@ namespace FitBridge_Application.Dtos.GymCourses;
 
 public class GymCoursesPtResponse
 {
+    public Guid CustomerPurchasedId { get; set; }
     public Guid Id { get; set; }
     public string Name { get; set; }
 

--- a/FitBridge_Application/MappingProfiles/BookingMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/BookingMappingProfile.cs
@@ -12,6 +12,7 @@ public class BookingMappingProfile : Profile
         CreateMap<Booking, GetCustomerBookingsResponse>()
         .ForMember(dest => dest.BookingId, opt => opt.MapFrom(src => src.Id))
         .ForMember(dest => dest.BookingDate, opt => opt.MapFrom(src => src.BookingDate))
+        .ForMember(dest => dest.SlotName, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.GymSlot != null ? src.PTGymSlot.GymSlot.Name : (string?)null))
         .ForMember(dest => dest.PtFreelanceStartTime, opt => opt.MapFrom(src => src.PtFreelanceStartTime))
         .ForMember(dest => dest.PtFreelanceEndTime, opt => opt.MapFrom(src => src.PtFreelanceEndTime))
         .ForMember(dest => dest.PTGymSlotId, opt => opt.MapFrom(src => src.PTGymSlotId))
@@ -21,6 +22,8 @@ public class BookingMappingProfile : Profile
         .ForMember(dest => dest.Note, opt => opt.MapFrom(src => src.Note))
         .ForMember(dest => dest.NutritionTip, opt => opt.MapFrom(src => src.NutritionTip))
         .ForMember(dest => dest.GymSlotStartTime, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.GymSlot != null ? src.PTGymSlot.GymSlot.StartTime : (TimeOnly?)null))
-        .ForMember(dest => dest.GymSlotEndTime, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.GymSlot != null ? src.PTGymSlot.GymSlot.EndTime : (TimeOnly?)null));
+        .ForMember(dest => dest.GymSlotEndTime, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.GymSlot != null ? src.PTGymSlot.GymSlot.EndTime : (TimeOnly?)null))
+        .ForMember(dest => dest.PtName, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.PT != null ? src.PTGymSlot.PT.FullName : (string?)null))
+        .ForMember(dest => dest.PtAvatarUrl, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.PT != null ? src.PTGymSlot.PT.AvatarUrl : (string?)null));
     }
 }

--- a/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
@@ -11,6 +11,7 @@ public class CustomerPurchasedMappingProfile : Profile
     public CustomerPurchasedMappingProfile()
     {
         CreateProjection<CustomerPurchased, GymCoursesPtResponse>()
+            .ForMember(dest => dest.CustomerPurchasedId, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId))
             .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.GymOwnerId))
             .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.Name))

--- a/FitBridge_Application/Specifications/Bookings/GetCustomerBookings/GetCustomerBookingByCustomerIdSpecification.cs
+++ b/FitBridge_Application/Specifications/Bookings/GetCustomerBookings/GetCustomerBookingByCustomerIdSpecification.cs
@@ -14,6 +14,7 @@ public class GetCustomerBookingByCustomerIdSpecification : BaseSpecification<Boo
     {
         AddInclude(x => x.PTGymSlot);
         AddInclude(x => x.PTGymSlot.GymSlot);
+        AddInclude(x => x.PTGymSlot.PT);
         if (parameters.DoApplyPaging)
         {
             AddPaging((parameters.Page - 1) * parameters.Size, parameters.Size);


### PR DESCRIPTION
Extended GetCustomerBookingsResponse to include SlotName, PtName, and PtAvatarUrl. Updated mapping profiles and specifications to support these new fields and ensure related entities are included for mapping. Also added CustomerPurchasedId to GymCoursesPtResponse.