### PR TITLE
#92 Change Template-Notification relationship to one-to-many

### DIFF
--- a/FitBridge_Domain/Entities/MessageAndReview/Template.cs
+++ b/FitBridge_Domain/Entities/MessageAndReview/Template.cs
@@ -12,5 +12,5 @@ public class Template : BaseEntity
     public string TemplateTile { get; set; }
     public string TemplateBody { get; set; } = null!;
 
-    public Notification InAppNotification { get; set; } = new Notification();
+    public ICollection<Notification> Notifications { get; set; } = [];
 }

--- a/FitBridge_Infrastructure/Configurations/NotificationConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/NotificationConfiguration.cs
@@ -17,7 +17,7 @@ public class NotificationConfiguration : IEntityTypeConfiguration<Notification>
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);
 
-        builder.HasOne(e => e.Template).WithOne(e => e.InAppNotification).HasForeignKey<Notification>(e => e.TemplateId);
+        builder.HasOne(e => e.Template).WithMany(e => e.Notifications).HasForeignKey(e => e.TemplateId);
         builder.HasOne(e => e.User).WithMany(e => e.InAppNotifications).HasForeignKey(e => e.UserId);
         
         builder.Property(e => e.ReadAt).HasDefaultValue(null);


### PR DESCRIPTION
Updated the Template entity to hold a collection of Notifications instead of a single Notification. Modified NotificationConfiguration to reflect the new one-to-many relationship between Template and Notification.