### PR TITLE
#92 Add freelance PT booking requests and scheduling

### DIFF
--- a/FitBridge_API/Controllers/BookingsController.cs
+++ b/FitBridge_API/Controllers/BookingsController.cs
@@ -11,6 +11,9 @@ using FitBridge_Application.Dtos.Bookings;
 using FitBridge_Application.Specifications.Bookings.GetGymSlotForBooking;
 using FitBridge_Application.Features.Bookings.GetGymSlotForBooking;
 using FitBridge_Application.Dtos.GymSlots;
+using FitBridge_Application.Specifications.Bookings.GetFreelancePtSchedule;
+using FitBridge_Application.Features.Bookings.GetFreelancePtSchedule;
+using FitBridge_Application.Features.Bookings.CreateRequestBooking;
 
 namespace FitBridge_API.Controllers;
 
@@ -57,5 +60,21 @@ public class BookingsController(IMediator _mediator) : _BaseApiController
         var result = await _mediator.Send(new GetGymSlotForBookingQuery { Params = parameters });
         var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
         return Ok(new BaseResponse<Pagination<GetPtGymSlotForBookingResponse>>(StatusCodes.Status200OK.ToString(), "Slot retrieved successfully", pagination));
+    }
+
+    [HttpPost("request-booking")]
+    [Authorize(Roles = ProjectConstant.UserRoles.Customer + "," + ProjectConstant.UserRoles.FreelancePT)]
+    public async Task<IActionResult> CreateRequestBooking([FromBody] CreateRequestBookingCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<List<CreateRequestBookingResponseDto>>(StatusCodes.Status200OK.ToString(), "Booking created successfully", result));
+    }
+
+    [HttpGet("freelance-pt-schedule")]
+    public async Task<IActionResult> GetFreelancePtSchedule([FromQuery] GetFreelancePtScheduleParams parameters)
+    {
+        var result = await _mediator.Send(new GetFreelancePtScheduleQuery { Params = parameters });
+        var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
+        return Ok(new BaseResponse<Pagination<GetFreelancePtScheduleResponse>>(StatusCodes.Status200OK.ToString(), "Schedule retrieved successfully", pagination));
     }
 }

--- a/FitBridge_Application/Commons/Constants/ProjectConstant.cs
+++ b/FitBridge_Application/Commons/Constants/ProjectConstant.cs
@@ -21,4 +21,10 @@ public static class ProjectConstant
     public const int GymSlotDuration = 1;
 
     public const decimal CommissionRate = 0.1m;
+    public const int MaxRetries = 3;
+    public static class EmailTypes
+    {
+        public const string InformationEmail = "InformationEmail";
+        public const string RegistrationConfirmationEmail = "RegistrationConfirmationEmail";
+    }
 }

--- a/FitBridge_Application/Dtos/Bookings/CreateRequestBookingDto.cs
+++ b/FitBridge_Application/Dtos/Bookings/CreateRequestBookingDto.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using FitBridge_Domain.Enums.Trainings;
+
+namespace FitBridge_Application.Dtos.Bookings;
+
+public class CreateRequestBookingDto
+{
+    public string? BookingName { get; set; }
+    public DateOnly BookingDate { get; set; }
+
+    public TimeOnly PtFreelanceStartTime { get; set; }
+
+    public TimeOnly PtFreelanceEndTime { get; set; }
+
+    [EnumDataType(typeof(RequestType), ErrorMessage = "RequestType must be a valid value: CustomerUpdate, PtUpdate, CustomerCreate, or PtCreate")]
+    public RequestType RequestType { get; set; }
+}

--- a/FitBridge_Application/Dtos/Bookings/CreateRequestBookingResponseDto.cs
+++ b/FitBridge_Application/Dtos/Bookings/CreateRequestBookingResponseDto.cs
@@ -1,0 +1,17 @@
+using System;
+using FitBridge_Domain.Enums.Trainings;
+
+namespace FitBridge_Application.Dtos.Bookings;
+
+public class CreateRequestBookingResponseDto
+{
+    public Guid Id { get; set; }
+    public string? BookingName { get; set; }
+    public DateOnly BookingDate { get; set; }
+
+    public TimeOnly StartTime { get; set; }
+
+    public TimeOnly EndTime { get; set; }
+    public Guid CustomerId { get; set; }
+    public RequestType RequestType { get; set; }
+}

--- a/FitBridge_Application/Dtos/Bookings/GetFreelancePtScheduleResponse.cs
+++ b/FitBridge_Application/Dtos/Bookings/GetFreelancePtScheduleResponse.cs
@@ -1,0 +1,26 @@
+using System;
+using FitBridge_Domain.Enums.Trainings;
+
+namespace FitBridge_Application.Dtos.Bookings;
+
+public class GetFreelancePtScheduleResponse
+{
+    public Guid BookingId { get; set; }
+    public string? BookingName { get; set; }
+    public DateOnly BookingDate { get; set; }
+
+    public TimeOnly? PtFreelanceStartTime { get; set; }
+
+    public TimeOnly? PtFreelanceEndTime { get; set; }
+    public Guid CustomerId { get; set; }
+
+    public Guid CustomerPurchasedId { get; set; }
+
+    public SessionStatus SessionStatus { get; set; }
+    public string? CustomerName { get; set; }
+    public string? CustomerAvatarUrl { get; set; }
+
+    public string? Note { get; set; }
+
+    public string? NutritionTip { get; set; }
+}

--- a/FitBridge_Application/Dtos/Emails/AccountInformationEmailData.cs
+++ b/FitBridge_Application/Dtos/Emails/AccountInformationEmailData.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Emails;
+
+public class AccountInformationEmailData
+{
+    public Guid UserId { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public string PhoneNumber { get; set; } = string.Empty;
+    public DateTime Dob { get; set; }
+    public bool IsMale { get; set; }
+    public string Password { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public string? GymName { get; set; }
+    public string? TaxCode { get; set; }
+    public string? ConfirmationLink { get; set; }
+    public string? EmailType { get; set; }
+}

--- a/FitBridge_Application/Dtos/Jobs/JobInfoDto.cs
+++ b/FitBridge_Application/Dtos/Jobs/JobInfoDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Jobs;
+
+public class JobInfoDto
+{
+    public string JobName { get; set; } = string.Empty;
+    public string JobGroup { get; set; } = string.Empty;
+    public string JobType { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string TriggerState { get; set; } = string.Empty;
+    public DateTime? NextFireTime { get; set; }
+    public DateTime? PreviousFireTime { get; set; }
+    public DateTime? StartTime { get; set; }
+    public Dictionary<string, string> JobData { get; set; } = new();
+}

--- a/FitBridge_Application/Dtos/Jobs/ProfitJobScheduleDto.cs
+++ b/FitBridge_Application/Dtos/Jobs/ProfitJobScheduleDto.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Jobs;
+
+public class ProfitJobScheduleDto
+{
+    public Guid CustomerPurchasedId { get; set; }
+    public DateOnly ProfitDistributionDate { get; set; }
+}

--- a/FitBridge_Application/Features/Bookings/CreateBooking/CreateRequestBookingCommand.cs
+++ b/FitBridge_Application/Features/Bookings/CreateBooking/CreateRequestBookingCommand.cs
@@ -1,0 +1,14 @@
+using System;
+using FitBridge_Application.Dtos.Bookings;
+using FitBridge_Domain.Enums.Trainings;
+using MediatR;
+
+namespace FitBridge_Application.Features.Bookings.CreateRequestBooking;
+
+public class CreateRequestBookingCommand : IRequest<List<CreateRequestBookingResponseDto>>
+{
+    public Guid CustomerPurchasedId { get; set; }
+    public Guid PtId { get; set; }
+
+    public List<CreateRequestBookingDto> RequestBookings { get; set; }
+}

--- a/FitBridge_Application/Features/Bookings/CreateBooking/CreateRequestBookingCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/CreateBooking/CreateRequestBookingCommandHandler.cs
@@ -1,0 +1,83 @@
+using System;
+using MediatR;
+using FitBridge_Application.Interfaces.Utils;
+using Microsoft.AspNetCore.Http;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Gyms;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Application.Specifications.Bookings;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Enums.Trainings;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByCustomerId;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByCustomerIdAndPtId;
+using FitBridge_Application.Specifications.Bookings.GetFreelancePtBookingForValidation;
+using FitBridge_Application.Dtos.Bookings;
+using AutoMapper;
+using FitBridge_Application.Commons.Constants;
+
+namespace FitBridge_Application.Features.Bookings.CreateRequestBooking;
+
+public class CreateRequestBookingCommandHandler(IUserUtil _userUtil, IHttpContextAccessor _httpContextAccessor, IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<CreateRequestBookingCommand, List<CreateRequestBookingResponseDto>>
+{
+    public async Task<List<CreateRequestBookingResponseDto>> Handle(CreateRequestBookingCommand request, CancellationToken cancellationToken)
+    {
+        var userId = _userUtil.GetAccountId(_httpContextAccessor.HttpContext);
+        if (userId == null)
+        {
+            throw new NotFoundException("User not found");
+        }
+        var role = _userUtil.GetUserRole(_httpContextAccessor.HttpContext);
+        // var bookingSpec = new GetBookingForValidationSpec(userId.Value, request.BookingDate, request.PtFreelanceStartTime, request.PtFreelanceEndTime);
+        // var booking = await _unitOfWork.Repository<Booking>().GetBySpecificationAsync(bookingSpec, false);
+        // if (booking != null)
+        // {
+        //     throw new DuplicateException($"Customer have course at this time, booking that overlapped: {booking.Id}");
+        // }
+        // var freelancePtBookingSpec = new GetFreelancePtBookingForValidationSpec(userId.Value, request.BookingDate, request.PtFreelanceStartTime, request.PtFreelanceEndTime);
+        // var freelancePtBooking = await _unitOfWork.Repository<Booking>().GetBySpecificationAsync(freelancePtBookingSpec, false);
+        // if (freelancePtBooking != null)
+        // {
+        //     throw new DuplicateException($"PT have course at this time booking that overlapped: {freelancePtBooking.Id}");
+        // }
+        var customerPurchased = await _unitOfWork.Repository<CustomerPurchased>().GetByIdAsync(request.CustomerPurchasedId);
+        if (customerPurchased == null)
+        {
+            throw new NotFoundException("Customer purchased not found");
+        }
+        if (customerPurchased.AvailableSessions <= 0)
+        {
+            throw new NotEnoughSessionException("Customer purchased not enough sessions");
+        }
+        if(customerPurchased.AvailableSessions - request.RequestBookings.Count <= 0)
+        {
+            throw new NotEnoughSessionException($"Available sessions is not enough, current available sessions is: {customerPurchased.AvailableSessions}");
+        }
+        var requestType = RequestType.CustomerCreate;
+        if (role.Equals(ProjectConstant.UserRoles.FreelancePT))
+        {
+            requestType = RequestType.PtCreate;
+        }
+        var response = new List<CreateRequestBookingResponseDto>();
+        foreach (var requestBooking in request.RequestBookings)
+        {
+            var insertRequestBooking = new BookingRequest
+            {
+                CustomerId = customerPurchased.CustomerId,
+                CustomerPurchasedId = customerPurchased.Id,
+                PtId = request.PtId,
+                BookingName = requestBooking.BookingName,
+                StartTime = requestBooking.PtFreelanceStartTime,
+                EndTime = requestBooking.PtFreelanceEndTime,
+                BookingDate = requestBooking.BookingDate,
+                RequestStatus = BookingRequestStatus.Pending,
+                RequestType = requestType,
+            };
+            response.Add(_mapper.Map<CreateRequestBookingResponseDto>(insertRequestBooking));
+            _unitOfWork.Repository<BookingRequest>().Insert(insertRequestBooking);
+        }
+
+        await _unitOfWork.CommitAsync();
+        return response;
+    }
+}

--- a/FitBridge_Application/Features/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleQuery.cs
+++ b/FitBridge_Application/Features/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleQuery.cs
@@ -1,0 +1,12 @@
+using System;
+using FitBridge_Application.Dtos.Bookings;
+using MediatR;
+using FitBridge_Application.Specifications.Bookings.GetFreelancePtSchedule;
+using FitBridge_Application.Dtos;
+
+namespace FitBridge_Application.Features.Bookings.GetFreelancePtSchedule;
+
+public class GetFreelancePtScheduleQuery : IRequest<PagingResultDto<GetFreelancePtScheduleResponse>>
+{
+    public GetFreelancePtScheduleParams Params { get; set; }
+}

--- a/FitBridge_Application/Features/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleQueryHandler.cs
+++ b/FitBridge_Application/Features/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleQueryHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.Bookings;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Specifications.Bookings.GetFreelancePtSchedule;
+using MediatR;
+using AutoMapper;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Application.Specifications;
+using FitBridge_Application.Interfaces.Utils;
+using Microsoft.AspNetCore.Http;
+using FitBridge_Domain.Exceptions;
+
+namespace FitBridge_Application.Features.Bookings.GetFreelancePtSchedule;
+
+public class GetFreelancePtScheduleQueryHandler(IUnitOfWork _unitOfWork, IMapper _mapper, IUserUtil _userUtil, IHttpContextAccessor _httpContextAccessor) : IRequestHandler<GetFreelancePtScheduleQuery, PagingResultDto<GetFreelancePtScheduleResponse>>
+{
+    public async Task<PagingResultDto<GetFreelancePtScheduleResponse>> Handle(GetFreelancePtScheduleQuery request, CancellationToken cancellationToken)
+    {
+        var userId = _userUtil.GetAccountId(_httpContextAccessor.HttpContext);
+        if (userId == null)
+        {
+            throw new NotFoundException("Pt not found");
+        }
+        var spec = new GetFreelancePtScheduleSpec(request.Params, userId.Value);
+        var bookings = await _unitOfWork.Repository<Booking>().GetAllWithSpecificationProjectedAsync<GetFreelancePtScheduleResponse>(spec, _mapper.ConfigurationProvider);
+        var totalItems = await _unitOfWork.Repository<Booking>().CountAsync(spec);
+        return new PagingResultDto<GetFreelancePtScheduleResponse>(totalItems, bookings);
+    }
+
+}

--- a/FitBridge_Application/Features/GymSlots/CustomerRegisterSlot/CustomerRegisterSlotCommandHandler.cs
+++ b/FitBridge_Application/Features/GymSlots/CustomerRegisterSlot/CustomerRegisterSlotCommandHandler.cs
@@ -47,6 +47,7 @@ public class CustomerRegisterSlotCommandHandler(IUnitOfWork _unitOfWork, IUserUt
             CustomerId = userId.Value,
             CustomerPurchasedId = request.CustomerPurchasedId,
             PTGymSlotId = request.PtGymSlotId,
+            PtId = ptGymSlot.PTId,
             BookingDate = ptGymSlot.RegisterDate,
             SessionStatus = SessionStatus.Booked,
         };

--- a/FitBridge_Application/Features/Identities/Registers/RegisterGymPT/RegisterGymPtCommandHandler.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterGymPT/RegisterGymPtCommandHandler.cs
@@ -11,7 +11,7 @@ using AutoMapper;
 
 namespace FitBridge_Application.Features.Identities.Registers.RegisterGymPT;
 
-public class RegisterGymPtCommandHandler(IApplicationUserService _applicationUserService, IEmailService emailService, IConfiguration _configuration, IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<RegisterGymPtCommand, CreateNewPTResponse>
+public class RegisterGymPtCommandHandler(IApplicationUserService _applicationUserService, IEmailService _emailService, IConfiguration _configuration, IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<RegisterGymPtCommand, CreateNewPTResponse>
 {
     public async Task<CreateNewPTResponse> Handle(RegisterGymPtCommand request, CancellationToken cancellationToken)
     {
@@ -42,7 +42,7 @@ public class RegisterGymPtCommandHandler(IApplicationUserService _applicationUse
         var isTestAccount = request.IsTestAccount ?? false;
         if (isTestAccount != true)
         {
-            await emailService.SendAccountInformationEmailAsync(user, request.Password, ProjectConstant.UserRoles.GymPT);
+            await _emailService.SendAccountInformationEmailAsync(user, request.Password, ProjectConstant.UserRoles.GymPT);
         }
 
         await _unitOfWork.CommitAsync();

--- a/FitBridge_Application/Features/Payments/CreatePaymentLink/CreatePaymentLinkCommandHandler.cs
+++ b/FitBridge_Application/Features/Payments/CreatePaymentLink/CreatePaymentLinkCommandHandler.cs
@@ -166,7 +166,7 @@ public class CreatePaymentLinkCommandHandler(IUserUtil _userUtil, IHttpContextAc
                 var userPackage = await _unitOfWork.Repository<CustomerPurchased>().GetBySpecificationAsync(new GetCustomerPurchasedByGymIdSpec(gymCoursePT.GymOwnerId, userId));
                 if (userPackage != null)
                 {
-                    throw new PackageExistException("Package of this gym course still not expired");
+                    throw new PackageExistException("Package of this gym still not expired");
                 }
             }
 

--- a/FitBridge_Application/Interfaces/Services/IEmailServices.cs
+++ b/FitBridge_Application/Interfaces/Services/IEmailServices.cs
@@ -1,3 +1,4 @@
+using FitBridge_Application.Dtos.Emails;
 using FitBridge_Domain.Entities.Identity;
 
 namespace FitBridge_Application.Interfaces.Services;
@@ -7,4 +8,6 @@ public interface IEmailService
     Task SendEmailAsync(string email, string subject, string body);
     Task SendRegistrationConfirmationEmailAsync(string email, string confirmationLink, string fullName);
     Task SendAccountInformationEmailAsync(ApplicationUser user, string password, string role);
+
+    Task ScheduleEmailAsync(AccountInformationEmailData emailData);
 }

--- a/FitBridge_Application/Interfaces/Services/IJobMonitoringService.cs
+++ b/FitBridge_Application/Interfaces/Services/IJobMonitoringService.cs
@@ -1,0 +1,9 @@
+using System;
+using FitBridge_Application.Dtos.Jobs;
+
+namespace FitBridge_Application.Interfaces.Services;
+
+public interface IJobMonitoringService
+{
+    Task<List<JobInfoDto>> GetAllScheduledJobsAsync();
+}

--- a/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
+++ b/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
@@ -1,0 +1,9 @@
+using System;
+using FitBridge_Application.Dtos.Jobs;
+
+namespace FitBridge_Application.Interfaces.Services;
+
+public interface IScheduleJobServices
+{
+    Task<bool> ScheduleProfitDistributionJob(ProfitJobScheduleDto profitJobScheduleDto);
+}

--- a/FitBridge_Application/Interfaces/Services/ITransactionService.cs
+++ b/FitBridge_Application/Interfaces/Services/ITransactionService.cs
@@ -1,4 +1,5 @@
 using System;
+using FitBridge_Application.Dtos.Jobs;
 
 namespace FitBridge_Application.Interfaces.Services;
 
@@ -7,4 +8,6 @@ public interface ITransactionService
     Task<bool> ExtendCourse(long orderCode);
     Task<bool> PurchasePt(long orderCode);
     Task<bool> DistributeProfit(Guid customerPurchasedId);
+    Task<bool> PurchaseFreelancePTPackage(long orderCode);
+    Task<bool> PurchaseGymCourse(long orderCode);
 }

--- a/FitBridge_Application/Interfaces/Utils/IUserUtil.cs
+++ b/FitBridge_Application/Interfaces/Utils/IUserUtil.cs
@@ -6,4 +6,6 @@ namespace FitBridge_Application.Interfaces.Utils;
 public interface IUserUtil
 {
     Guid? GetAccountId(HttpContext httpContext);
+    string? GetUserRole(HttpContext httpContext);
+
 }

--- a/FitBridge_Application/MappingProfiles/BookingMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/BookingMappingProfile.cs
@@ -25,5 +25,28 @@ public class BookingMappingProfile : Profile
         .ForMember(dest => dest.GymSlotEndTime, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.GymSlot != null ? src.PTGymSlot.GymSlot.EndTime : (TimeOnly?)null))
         .ForMember(dest => dest.PtName, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.PT != null ? src.PTGymSlot.PT.FullName : (string?)null))
         .ForMember(dest => dest.PtAvatarUrl, opt => opt.MapFrom(src => src.PTGymSlot != null && src.PTGymSlot.PT != null ? src.PTGymSlot.PT.AvatarUrl : (string?)null));
+
+        CreateMap<Booking, GetFreelancePtScheduleResponse>()
+        .ForMember(dest => dest.BookingId, opt => opt.MapFrom(src => src.Id))
+        .ForMember(dest => dest.BookingDate, opt => opt.MapFrom(src => src.BookingDate))
+        .ForMember(dest => dest.BookingName, opt => opt.MapFrom(src => src.BookingName))
+        .ForMember(dest => dest.PtFreelanceStartTime, opt => opt.MapFrom(src => src.PtFreelanceStartTime))
+        .ForMember(dest => dest.PtFreelanceEndTime, opt => opt.MapFrom(src => src.PtFreelanceEndTime))
+        .ForMember(dest => dest.CustomerId, opt => opt.MapFrom(src => src.CustomerId))
+        .ForMember(dest => dest.CustomerPurchasedId, opt => opt.MapFrom(src => src.CustomerPurchasedId))
+        .ForMember(dest => dest.SessionStatus, opt => opt.MapFrom(src => src.SessionStatus))
+        .ForMember(dest => dest.Note, opt => opt.MapFrom(src => src.Note))
+        .ForMember(dest => dest.NutritionTip, opt => opt.MapFrom(src => src.NutritionTip))
+        .ForMember(dest => dest.CustomerName, opt => opt.MapFrom(src => src.Customer.FullName))
+        .ForMember(dest => dest.CustomerAvatarUrl, opt => opt.MapFrom(src => src.Customer.AvatarUrl));
+
+        CreateMap<BookingRequest, CreateRequestBookingResponseDto>()
+        .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+        .ForMember(dest => dest.BookingDate, opt => opt.MapFrom(src => src.BookingDate))
+        .ForMember(dest => dest.BookingName, opt => opt.MapFrom(src => src.BookingName))
+        .ForMember(dest => dest.StartTime, opt => opt.MapFrom(src => src.StartTime))
+        .ForMember(dest => dest.EndTime, opt => opt.MapFrom(src => src.EndTime))
+        .ForMember(dest => dest.CustomerId, opt => opt.MapFrom(src => src.CustomerId))
+        .ForMember(dest => dest.RequestType, opt => opt.MapFrom(src => src.RequestType));
     }
 }

--- a/FitBridge_Application/Specifications/Bookings/GetFreelancePtBookingForValidate/GetFreelancePtBookingForValidationSpec.cs
+++ b/FitBridge_Application/Specifications/Bookings/GetFreelancePtBookingForValidate/GetFreelancePtBookingForValidationSpec.cs
@@ -1,0 +1,12 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.Trainings;
+
+namespace FitBridge_Application.Specifications.Bookings.GetFreelancePtBookingForValidation;
+
+public class GetFreelancePtBookingForValidationSpec : BaseSpecification<Booking>
+{
+    public GetFreelancePtBookingForValidationSpec(Guid ptId, DateOnly bookingDate, TimeOnly ptFreelanceStartTime, TimeOnly ptFreelanceEndTime) : base(x => x.PtId == ptId && x.BookingDate == bookingDate && !(x.PtFreelanceStartTime >= ptFreelanceEndTime || x.PtFreelanceEndTime <= ptFreelanceStartTime))
+    {
+    }
+}

--- a/FitBridge_Application/Specifications/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleParams.cs
+++ b/FitBridge_Application/Specifications/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleParams.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace FitBridge_Application.Specifications.Bookings.GetFreelancePtSchedule;
+
+public class GetFreelancePtScheduleParams : BaseParams
+{
+}

--- a/FitBridge_Application/Specifications/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleSpec.cs
+++ b/FitBridge_Application/Specifications/Bookings/GetFreelancePtSchedule/GetFreelancePtScheduleSpec.cs
@@ -1,0 +1,22 @@
+using System;
+using FitBridge_Domain.Entities.Trainings;
+
+namespace FitBridge_Application.Specifications.Bookings.GetFreelancePtSchedule;
+
+public class GetFreelancePtScheduleSpec : BaseSpecification<Booking>
+{
+    public GetFreelancePtScheduleSpec(GetFreelancePtScheduleParams parameters, Guid PtId) : base(x => x.PtId == PtId)
+    {
+        AddInclude(x => x.Customer);
+
+        if (parameters.DoApplyPaging)
+        {
+            AddPaging((parameters.Page - 1) * parameters.Size, parameters.Size);
+        }
+        else
+        {
+            parameters.Size = -1;
+            parameters.Page = -1;
+        }
+    }
+}

--- a/FitBridge_Application/Specifications/CustomerPurchaseds/GetCustomerPurchasedByCustomerIdAndPtId/GetCustomerPurchasedByCustomerIdAndPtIdSpec.cs
+++ b/FitBridge_Application/Specifications/CustomerPurchaseds/GetCustomerPurchasedByCustomerIdAndPtId/GetCustomerPurchasedByCustomerIdAndPtIdSpec.cs
@@ -1,0 +1,15 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.Gyms;
+
+namespace FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByCustomerIdAndPtId;
+
+public class GetCustomerPurchasedByCustomerIdAndPtIdSpec : BaseSpecification<CustomerPurchased>
+{
+    public GetCustomerPurchasedByCustomerIdAndPtIdSpec(Guid customerId, Guid ptId) : base(x => x.CustomerId == customerId
+    && x.ExpirationDate >= DateOnly.FromDateTime(DateTime.UtcNow)
+    && x.OrderItems.Any(x => x.FreelancePTPackage != null && x.FreelancePTPackage.PtId == ptId))
+    {
+        AddInclude(x => x.OrderItems);
+    }
+}

--- a/FitBridge_Domain/Entities/Gyms/CustomerPurchased.cs
+++ b/FitBridge_Domain/Entities/Gyms/CustomerPurchased.cs
@@ -15,4 +15,5 @@ public class CustomerPurchased : BaseEntity
     public UserGoal? UserGoal { get; set; }
     public ICollection<Booking> Bookings { get; set; } = new List<Booking>();
     public ICollection<Order> OrderThatExtend { get; set; } = new List<Order>();
+    public ICollection<BookingRequest> BookingRequests { get; set; } = new List<BookingRequest>();
 }

--- a/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
+++ b/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
@@ -60,6 +60,10 @@ namespace FitBridge_Domain.Entities.Identity
         public ICollection<OrderItem> OrderItems { get; set; } = new List<OrderItem>();
         public ICollection<MeetingSession> MeetingSessions { get; set; } = new List<MeetingSession>();
         public Wallet? Wallet { get; set; }
+        public ICollection<Booking> PtBookings { get; set; } = new List<Booking>();
+        public ICollection<BookingRequest> PtBookingRequests { get; set; } = new List<BookingRequest>();
+        public ICollection<BookingRequest> CustomerBookingRequests { get; set; } = new List<BookingRequest>();
+        public ICollection<Coupon> UsedCoupons { get; set; } = new List<Coupon>();
     }
 
 }

--- a/FitBridge_Domain/Entities/Orders/Coupon.cs
+++ b/FitBridge_Domain/Entities/Orders/Coupon.cs
@@ -19,6 +19,7 @@ public class Coupon : BaseEntity
     public int NumberOfUsedCoupon { get; set; }
 
     public ApplicationUser Creator { get; set; }
+    public ICollection<ApplicationUser> CouponUsers { get; set; } = new List<ApplicationUser>();
 
     public ICollection<Order> Orders { get; set; } = new List<Order>();
 }

--- a/FitBridge_Domain/Entities/Trainings/Booking.cs
+++ b/FitBridge_Domain/Entities/Trainings/Booking.cs
@@ -21,6 +21,9 @@ public class Booking : BaseEntity
     public Guid CustomerPurchasedId { get; set; }
 
     public SessionStatus SessionStatus { get; set; }
+    public Guid? PtId { get; set; }
+
+    public string? BookingName { get; set; }
 
     public string? Note { get; set; }
 
@@ -33,5 +36,7 @@ public class Booking : BaseEntity
     public CustomerPurchased CustomerPurchased { get; set; }
 
     public ICollection<SessionActivity> SessionActivities { get; set; } = new List<SessionActivity>();
+    public ApplicationUser? Pt { get; set; }
     public MeetingSession? MeetingSession { get; set; }
+    public ICollection<BookingRequest> BookingRequests { get; set; } = new List<BookingRequest>();
 }

--- a/FitBridge_Domain/Entities/Trainings/BookingRequest.cs
+++ b/FitBridge_Domain/Entities/Trainings/BookingRequest.cs
@@ -1,0 +1,27 @@
+using System;
+using FitBridge_Domain.Entities;
+using FitBridge_Domain.Entities.Gyms;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Domain.Enums.Trainings;
+
+namespace FitBridge_Domain.Entities.Trainings;
+
+public class BookingRequest : BaseEntity
+{
+    public Guid CustomerId { get; set; }
+    public Guid PtId { get; set; }
+    public Guid? TargetBookingId { get; set; }
+    public Guid CustomerPurchasedId { get; set; }
+    public string? Note { get; set; }
+    public TimeOnly StartTime { get; set; }
+    public TimeOnly EndTime { get; set; }
+    public string? BookingName { get; set; }
+    public BookingRequestStatus RequestStatus { get; set; }
+    public DateOnly BookingDate { get; set; }
+    public RequestType RequestType { get; set; }
+    public ApplicationUser Customer { get; set; }
+    public ApplicationUser Pt { get; set; }
+    public Booking? TargetBooking { get; set; }
+    public CustomerPurchased CustomerPurchased { get; set; }
+    
+}

--- a/FitBridge_Domain/Enums/Trainings/BookingRequestStatus.cs
+++ b/FitBridge_Domain/Enums/Trainings/BookingRequestStatus.cs
@@ -1,0 +1,8 @@
+namespace FitBridge_Domain.Enums.Trainings;
+
+public enum BookingRequestStatus
+{
+    Pending,
+    Approved,
+    Rejected
+}

--- a/FitBridge_Domain/Enums/Trainings/RequestType.cs
+++ b/FitBridge_Domain/Enums/Trainings/RequestType.cs
@@ -1,0 +1,9 @@
+namespace FitBridge_Domain.Enums.Trainings;
+
+public enum RequestType
+{
+    CustomerUpdate,
+    PtUpdate,
+    CustomerCreate,
+    PtCreate
+}

--- a/FitBridge_Infrastructure/Configurations/BookingConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/BookingConfiguration.cs
@@ -15,15 +15,17 @@ public class BookingConfiguration : IEntityTypeConfiguration<Booking>
         builder.Property(e => e.BookingDate).IsRequired(true);
         builder.Property(e => e.PtFreelanceStartTime).IsRequired(false);
         builder.Property(e => e.PtFreelanceEndTime).IsRequired(false);
+        builder.Property(e => e.BookingName).IsRequired(false);
         builder.Property(e => e.Note).IsRequired(false);
         builder.Property(e => e.NutritionTip).IsRequired(false);
         builder.Property(e => e.SessionStatus).IsRequired(true).HasDefaultValue(SessionStatus.Booked);
         builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);
-
+        builder.Property(e => e.PtId).IsRequired(false);
         builder.HasOne(e => e.Customer).WithMany(e => e.Bookings).HasForeignKey(e => e.CustomerId);
         builder.HasOne(e => e.PTGymSlot).WithOne(e => e.Booking).HasForeignKey<Booking>(e => e.PTGymSlotId);
         builder.HasOne(e => e.CustomerPurchased).WithMany(e => e.Bookings).HasForeignKey(e => e.CustomerPurchasedId);
+        builder.HasOne(e => e.Pt).WithMany(e => e.PtBookings).HasForeignKey(e => e.PtId);
     }
 }

--- a/FitBridge_Infrastructure/Configurations/BookingRequestConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/BookingRequestConfiguration.cs
@@ -1,0 +1,31 @@
+using System;
+using FitBridge_Domain.Entities.Trainings;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FitBridge_Infrastructure.Configurations;
+
+public class BookingRequestConfiguration : IEntityTypeConfiguration<BookingRequest>
+{
+    public void Configure(EntityTypeBuilder<BookingRequest> builder)
+    {
+        builder.ToTable("BookingRequests");
+        builder.Property(e => e.CustomerId).IsRequired(true);
+        builder.Property(e => e.PtId).IsRequired(true);
+        builder.Property(e => e.TargetBookingId).IsRequired(false);
+        builder.Property(e => e.CustomerPurchasedId).IsRequired(true);
+        builder.Property(e => e.Note).IsRequired(false);
+        builder.Property(e => e.StartTime).IsRequired(true);
+        builder.Property(e => e.EndTime).IsRequired(true);
+        builder.Property(e => e.BookingDate).IsRequired(true);
+        builder.Property(e => e.RequestType).IsRequired(true);
+        builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.IsEnabled).HasDefaultValue(true);
+
+        builder.HasOne(e => e.Customer).WithMany(e => e.CustomerBookingRequests).HasForeignKey(e => e.CustomerId);
+        builder.HasOne(e => e.Pt).WithMany(e => e.PtBookingRequests).HasForeignKey(e => e.PtId);
+        builder.HasOne(e => e.TargetBooking).WithMany(e => e.BookingRequests).HasForeignKey(e => e.TargetBookingId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(e => e.CustomerPurchased).WithMany(e => e.BookingRequests).HasForeignKey(e => e.CustomerPurchasedId);
+    }
+}

--- a/FitBridge_Infrastructure/Configurations/CouponConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/CouponConfiguration.cs
@@ -22,7 +22,10 @@ public class CouponConfiguration : IEntityTypeConfiguration<Coupon>
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);
         builder.Property(e => e.IsActive).HasDefaultValue(true);
         builder.Property(e => e.NumberOfUsedCoupon).HasDefaultValue(0);
-        builder.HasIndex(e => new {e.CouponCode, e.IsEnabled}).IsUnique();
+        builder.HasIndex(e => new { e.CouponCode, e.IsEnabled }).IsUnique();
         builder.HasOne(e => e.Creator).WithMany(e => e.Coupons).HasForeignKey(e => e.CreatorId);
+        
+        builder.HasMany(e => e.CouponUsers).WithMany(e => e.UsedCoupons)
+        .UsingEntity(j => j.ToTable("CouponUsers"));
     }
 }

--- a/FitBridge_Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/FitBridge_Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using FitBridge_Infrastructure.Persistence;
 using FitBridge_Infrastructure.Seeder;
 using FitBridge_Infrastructure.Services;
 using FitBridge_Infrastructure.Services.Implements;
+using FitBridge_Infrastructure.Services.Jobs;
 using FitBridge_Infrastructure.Services.Notifications;
 using FitBridge_Infrastructure.Services.Notifications.Helpers;
 using FitBridge_Infrastructure.Services.Templating;
@@ -112,6 +113,7 @@ namespace FitBridge_Infrastructure.Extensions
             services.AddScoped<IPayOSService, PayOSService>();
             services.AddScoped<ITransactionService, TransactionsService>();
             services.AddHostedService<NotificationsBackgroundService>();
+            services.AddScoped<IScheduleJobServices, ScheduleJobServices>();
         }
     }
 }

--- a/FitBridge_Infrastructure/Jobs/SendAccountInformationEmailJob.cs
+++ b/FitBridge_Infrastructure/Jobs/SendAccountInformationEmailJob.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using FitBridge_Application.Dtos.Emails;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Domain.Exceptions;
+using Quartz;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Application.Commons.Constants;
+
+namespace FitBridge_Infrastructure.Jobs;
+
+public class SendAccountInformationEmailJob(IEmailService _emailService, ILogger<SendAccountInformationEmailJob> _logger) : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var maxRetries = ProjectConstant.MaxRetries;
+        var currentRetry = context.JobDetail.JobDataMap.GetIntValue("currentRetry");
+        var emailDataJson = context.JobDetail.JobDataMap.GetString("emailData") ?? throw new NotFoundException("Email data not found");
+
+        var emailData = JsonSerializer.Deserialize<AccountInformationEmailData>(emailDataJson) ?? throw new NotFoundException("Email data not found");
+        _logger.LogInformation("SendAccountInformationEmailJob started for user: {Email}, Role: {Role}",
+            emailData.Email, emailData.Role);
+
+        try
+        {
+            var user = new ApplicationUser
+            {
+                Id = emailData.UserId,
+                Email = emailData.Email,
+                FullName = emailData.FullName,
+                PhoneNumber = emailData.PhoneNumber,
+                Dob = emailData.Dob,
+                IsMale = emailData.IsMale,
+                GymName = emailData.GymName ?? "",
+                TaxCode = emailData.TaxCode ?? ""
+            };
+
+            if (emailData.EmailType == ProjectConstant.EmailTypes.RegistrationConfirmationEmail)
+            {
+                await _emailService.SendRegistrationConfirmationEmailAsync(emailData.Email, emailData.ConfirmationLink, emailData.FullName);
+            }
+            else
+            {
+                await _emailService.SendAccountInformationEmailAsync(user, emailData.Password, emailData.Role);
+            }
+            _logger.LogInformation("Email sent successfully to: {Email}", emailData.Email);
+
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Failed to send email to: {emailData.Email}, Role: {emailData.Role}, Retry: {currentRetry + 1}/{maxRetries}");
+            if (currentRetry < maxRetries)
+            {
+                context.JobDetail.JobDataMap.Put("currentRetry", currentRetry + 1);
+                var newTrigger = context.Trigger.GetTriggerBuilder()
+                .StartAt(DateTimeOffset.UtcNow.AddSeconds(20))
+                .Build();
+                await context.Scheduler.RescheduleJob(context.Trigger.Key, newTrigger);
+
+                _logger.LogInformation("Rescheduled email job for {Email} to retry in {Delay} seconds",
+                    emailData.Email, 20);
+            }
+            else
+            {
+                _logger.LogCritical("Failed to send email after {MaxRetries} attempts for user: {Email}",
+                    maxRetries, emailData.Email);
+                throw new BusinessException($"Failed to send email after {maxRetries} attempts for user: {emailData.Email}");
+            }
+        }
+    }
+}

--- a/FitBridge_Infrastructure/Services/Jobs/ScheduleJobServices.cs
+++ b/FitBridge_Infrastructure/Services/Jobs/ScheduleJobServices.cs
@@ -1,0 +1,39 @@
+using System;
+using FitBridge_Application.Dtos.Jobs;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Infrastructure.Jobs;
+using Quartz;
+using Microsoft.Extensions.Logging;
+
+namespace FitBridge_Infrastructure.Services.Jobs;
+
+public class ScheduleJobServices(ISchedulerFactory _schedulerFactory, ILogger<ScheduleJobServices> _logger) : IScheduleJobServices
+{
+    public async Task<bool> ScheduleProfitDistributionJob(ProfitJobScheduleDto profitJobScheduleDto)
+    {
+        var jobKey = new JobKey($"ProfitDistribution_{profitJobScheduleDto.CustomerPurchasedId}", "ProfitDistribution");
+        var triggerKey = new TriggerKey($"ProfitDistribution_{profitJobScheduleDto.CustomerPurchasedId}_Trigger", "ProfitDistribution");
+        var jobData = new JobDataMap
+        {
+            { "customerPurchasedId", profitJobScheduleDto.CustomerPurchasedId.ToString() }
+        };
+        var job = JobBuilder.Create<DistributeProfitJob>()
+        .WithIdentity(jobKey)
+        .SetJobData(jobData)
+        .Build();
+
+        var triggerTime = profitJobScheduleDto.ProfitDistributionDate.ToDateTime(TimeOnly.MinValue);
+        var trigger = TriggerBuilder.Create()
+        .WithIdentity(triggerKey)
+        .StartAt(triggerTime)
+        .Build();
+        
+        await _schedulerFactory.GetScheduler().Result
+        .ScheduleJob(job, trigger);
+        
+        _logger.LogInformation(
+        "Scheduled profit distribution job for CustomerPurchased {CustomerPurchasedId} at {TriggerTime}",
+        profitJobScheduleDto.CustomerPurchasedId, triggerTime);
+        return true;
+    }
+}

--- a/FitBridge_Infrastructure/Utils/UserUtil.cs
+++ b/FitBridge_Infrastructure/Utils/UserUtil.cs
@@ -26,4 +26,23 @@ public class UserUtil : IUserUtil
         }
         return accountId;
     }
+
+    public string? GetUserRole(HttpContext httpContext)
+    {
+        if (httpContext.User == null)
+        {
+            return null;
+        }
+
+        // The role is stored as ClaimTypes.Role in the access token
+        var roleClaim = httpContext.User.FindFirst(ClaimTypes.Role);
+        if (roleClaim == null)
+        {
+            return null;
+        }
+
+        // If multiple roles, get the first one
+        var roles = roleClaim.Value.Split(',');
+        return roles.FirstOrDefault();
+    }
 }


### PR DESCRIPTION
Introduces booking requests for freelance PTs, including new DTOs, entities, specifications, and API endpoints for creating and retrieving freelance PT schedules. Adds job scheduling interfaces and implementations for profit distribution and account information emails. Updates domain models, mapping profiles, and configurations to support booking requests and related relationships. Refactors registration and transaction logic to use scheduled emails and profit jobs. Minor fixes and improvements to existing handlers and constants.