### PR TITLE
#92 Add reject booking request feature

### DIFF
--- a/FitBridge_API/Controllers/BookingsController.cs
+++ b/FitBridge_API/Controllers/BookingsController.cs
@@ -19,6 +19,8 @@ using FitBridge_Application.Features.Bookings.RequestEditBooking;
 using FitBridge_Application.Features.Bookings.AcceptEditBookingRequest;
 using FitBridge_Application.Specifications.Bookings.GetBookingRequests;
 using FitBridge_Application.Features.Bookings.GetBookingRequest;
+using FitBridge_Application.Features.Bookings.CreateBooking;
+using FitBridge_Application.Features.Bookings.RejectBookingRequest;
 
 namespace FitBridge_API.Controllers;
 
@@ -219,5 +221,30 @@ public class BookingsController(IMediator _mediator) : _BaseApiController
         var result = await _mediator.Send(new GetBookingRequestQuery { Params = parameters });
         var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
         return Ok(new BaseResponse<Pagination<GetBookingRequestResponse>>(StatusCodes.Status200OK.ToString(), "Booking request retrieved successfully", pagination));
+    }
+
+    /// <summary>
+    /// Reject a booking request for customer and freelance pt
+    /// </summary>
+    /// <param name="command">The command containing the booking request ID to reject</param>
+    /// <returns>The ID of the rejected booking request</returns>
+    /// <remarks>
+    /// Sample request:
+    /// 
+    ///     POST /api/v1/bookings/reject-booking-request
+    ///     {
+    ///         "bookingRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    ///     }
+    ///     
+    /// Validation checks:
+    /// - Request must be in "Pending" status
+    /// - Target booking must exist
+    /// </remarks>
+    [Authorize(Roles = ProjectConstant.UserRoles.Customer + "," + ProjectConstant.UserRoles.FreelancePT)]
+    [HttpPost("reject-booking-request")]
+    public async Task<IActionResult> RejectBookingRequest([FromBody] RejectBookingRequestCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Booking request rejected successfully", result));
     }
 }

--- a/FitBridge_Application/Features/Bookings/RejectBookingRequest/RejectBookingRequestCommand.cs
+++ b/FitBridge_Application/Features/Bookings/RejectBookingRequest/RejectBookingRequestCommand.cs
@@ -1,0 +1,9 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.Bookings.RejectBookingRequest;
+
+public class RejectBookingRequestCommand : IRequest<bool>
+{
+    public Guid BookingRequestId { get; set; }
+}

--- a/FitBridge_Application/Features/Bookings/RejectBookingRequest/RejectBookingRequestCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/RejectBookingRequest/RejectBookingRequestCommandHandler.cs
@@ -1,0 +1,29 @@
+using System;
+using MediatR;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Enums.Trainings;
+using FitBridge_Domain.Exceptions;
+
+namespace FitBridge_Application.Features.Bookings.RejectBookingRequest;
+
+public class RejectBookingRequestCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<RejectBookingRequestCommand, bool>
+{
+    public async Task<bool> Handle(RejectBookingRequestCommand request, CancellationToken cancellationToken)
+    {
+        var bookingRequest = await _unitOfWork.Repository<BookingRequest>().GetByIdAsync(request.BookingRequestId);
+        if (bookingRequest == null)
+        {
+            throw new NotFoundException("Booking request not found");
+        }
+        if(bookingRequest.RequestStatus != BookingRequestStatus.Pending)
+        {
+            throw new BusinessException("Booking request is not pending, current status: " + bookingRequest.RequestStatus);
+        }
+        bookingRequest.RequestStatus = BookingRequestStatus.Rejected;
+        bookingRequest.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<BookingRequest>().Update(bookingRequest);
+        await _unitOfWork.CommitAsync();
+        return true;
+    }
+}

--- a/FitBridge_Domain/Enums/MessageAndReview/EnumContentType.cs
+++ b/FitBridge_Domain/Enums/MessageAndReview/EnumContentType.cs
@@ -12,6 +12,14 @@
 
         PaymentRequest,
 
-        PackageBought
+        PackageBought,
+
+        CreateBookingRequest, // Customer/FreelancePT create a booking request to create a booking
+
+        EditBookingRequest, // Customer/FreelancePT create a request to edit a booking
+
+        RejectBookingRequest, // Customer/FreelancePT reject a booking request
+
+        AcceptBookingRequest, // Customer/FreelancePT accept a booking request
     }
 }


### PR DESCRIPTION
Introduced the ability for customers and freelance PTs to reject booking requests. Added new API endpoint, command, and handler for rejecting booking requests, including validation for pending status. Updated EnumContentType to include related booking request actions.