### PR TITLE
#92 Make message status timestamps nullable and update configs

### DIFF
--- a/FitBridge_Domain/Entities/MessageAndReview/MessageStatus.cs
+++ b/FitBridge_Domain/Entities/MessageAndReview/MessageStatus.cs
@@ -9,11 +9,11 @@ public class MessageStatus : BaseEntity
 
     public Guid UserId { get; set; }
 
-    public DateTime SentAt { get; set; }
+    public DateTime? SentAt { get; set; }
 
-    public DateTime DeliveredAt { get; set; }
+    public DateTime? DeliveredAt { get; set; }
 
-    public DateTime ReadAt { get; set; }
+    public DateTime? ReadAt { get; set; }
 
     public Message Message { get; set; }
 

--- a/FitBridge_Infrastructure/Configurations/MessageStatusConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/MessageStatusConfiguration.cs
@@ -15,9 +15,9 @@ public class MessageStatusConfiguration : IEntityTypeConfiguration<MessageStatus
         builder.HasKey(e => new { e.MessageId, e.UserId });
         builder.Property(e => e.MessageId).IsRequired(true);
         builder.Property(e => e.UserId).IsRequired(true);
-        builder.Property(e => e.SentAt).IsRequired(true);
-        builder.Property(e => e.DeliveredAt).IsRequired(true);
-        builder.Property(e => e.ReadAt).IsRequired(true);
+        builder.Property(e => e.SentAt).IsRequired(false);
+        builder.Property(e => e.DeliveredAt).IsRequired(false);
+        builder.Property(e => e.ReadAt).IsRequired(false);
         builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);

--- a/FitBridge_Infrastructure/Configurations/PushNotificationTokensConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/PushNotificationTokensConfiguration.cs
@@ -20,6 +20,7 @@ public class PushNotificationTokensConfiguration : IEntityTypeConfiguration<Push
             convertToProviderExpression: s => s.ToString(),
             convertFromProviderExpression: s => Enum.Parse<PlatformEnum>(s))
             .IsRequired(true);
+        builder.HasIndex(e => e.DeviceToken).IsUnique();
 
         builder.HasOne(e => e.User).WithMany(e => e.PushNotificationTokens).HasForeignKey(e => e.UserId);
     }


### PR DESCRIPTION
Changed SentAt, DeliveredAt, and ReadAt in MessageStatus to nullable DateTime to allow for missing timestamps. Updated MessageStatusConfiguration to reflect these properties as not required. Added unique index on DeviceToken in PushNotificationTokensConfiguration to prevent duplicate tokens.