### PR TITLE
#92 Refactor profit distribution to use OrderItemId

### DIFF
--- a/FitBridge_Application/Dtos/GymCourses/GymCoursesPtResponse.cs
+++ b/FitBridge_Application/Dtos/GymCourses/GymCoursesPtResponse.cs
@@ -7,21 +7,22 @@ namespace FitBridge_Application.Dtos.GymCourses;
 public class GymCoursesPtResponse
 {
     public Guid CustomerPurchasedId { get; set; }
-    public Guid Id { get; set; }
+    public Guid? Id { get; set; }
     public string Name { get; set; }
 
     public decimal Price { get; set; }
 
-    public Guid GymPtId { get; set; }
+    public Guid? GymPtId { get; set; }
     public DateOnly ExpirationDate { get; set; }
     public int AvailableSessions { get; set; }
 
-    public TypeCourseEnum Type { get; set; }
+    public TypeCourseEnum? Type { get; set; }
 
     public string Description { get; set; }
 
     public string ImageUrl { get; set; }
 
-    public Guid GymOwnerId { get; set; }
-    public GymPtResponseDto GymPt { get; set; }
+    public Guid? GymOwnerId { get; set; }
+    public PackageType? PackageType { get; set; }
+    public GymPtResponseDto? Pt { get; set; }
 }

--- a/FitBridge_Application/Dtos/Jobs/ProfitJobScheduleDto.cs
+++ b/FitBridge_Application/Dtos/Jobs/ProfitJobScheduleDto.cs
@@ -4,6 +4,6 @@ namespace FitBridge_Application.Dtos.Jobs;
 
 public class ProfitJobScheduleDto
 {
-    public Guid CustomerPurchasedId { get; set; }
+    public Guid OrderItemId { get; set; }
     public DateOnly ProfitDistributionDate { get; set; }
 }

--- a/FitBridge_Application/Features/Payments/CreatePaymentLink/CreatePaymentLinkCommandHandler.cs
+++ b/FitBridge_Application/Features/Payments/CreatePaymentLink/CreatePaymentLinkCommandHandler.cs
@@ -166,11 +166,7 @@ public class CreatePaymentLinkCommandHandler(IUserUtil _userUtil, IHttpContextAc
                 var userPackage = await _unitOfWork.Repository<CustomerPurchased>().GetBySpecificationAsync(new GetCustomerPurchasedByGymIdSpec(gymCoursePT.GymOwnerId, userId));
                 if (userPackage != null)
                 {
-                    if(userPackage.AvailableSessions <= 0)
-                    {
-                        throw new PackageExistException($"Package of this gym still not expired, customer purchased id: {userPackage.Id}, package expiration date: {userPackage.ExpirationDate}, please extend the package");
-                    }
-                    throw new PackageExistException($"Package of this gym still not expired, customer purchased id: {userPackage.Id}, package expiration date: {userPackage.ExpirationDate}");
+                    throw new PackageExistException($"Package of this gym still not expired, customer purchased id: {userPackage.Id}, package expiration date: {userPackage.ExpirationDate} please extend the package");
                 }
             }
 
@@ -185,7 +181,7 @@ public class CreatePaymentLinkCommandHandler(IUserUtil _userUtil, IHttpContextAc
                 var userPackage = await _unitOfWork.Repository<CustomerPurchased>().GetBySpecificationAsync(new GetCustomerPurchasedByFreelancePtIdSpec(freelancePTPackage.PtId, userId));
                 if (userPackage != null)
                 {
-                    throw new PackageExistException($"Package of this freelance PT still not expired, customer purchased id: {userPackage.Id}, package expiration date: {userPackage.ExpirationDate}");
+                    throw new PackageExistException($"Package of this freelance PT still not expired, customer purchased id: {userPackage.Id}, package expiration date: {userPackage.ExpirationDate} please extend the package");
                 }
             }
         }

--- a/FitBridge_Application/Interfaces/Services/ITransactionService.cs
+++ b/FitBridge_Application/Interfaces/Services/ITransactionService.cs
@@ -7,7 +7,7 @@ public interface ITransactionService
 {
     Task<bool> ExtendCourse(long orderCode);
     Task<bool> PurchasePt(long orderCode);
-    Task<bool> DistributeProfit(Guid customerPurchasedId);
+    Task<bool> DistributeProfit(Guid orderItemId);
     Task<bool> PurchaseFreelancePTPackage(long orderCode);
     Task<bool> PurchaseGymCourse(long orderCode);
 }

--- a/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
@@ -3,6 +3,7 @@ using AutoMapper;
 using FitBridge_Domain.Entities.Gyms;
 using FitBridge_Application.Dtos.GymCourses;
 using FitBridge_Application.Dtos.CustomerPurchaseds;
+using FitBridge_Domain.Enums.GymCourses;
 
 namespace FitBridge_Application.MappingProfiles;
 
@@ -12,16 +13,17 @@ public class CustomerPurchasedMappingProfile : Profile
     {
         CreateProjection<CustomerPurchased, GymCoursesPtResponse>()
             .ForMember(dest => dest.CustomerPurchasedId, opt => opt.MapFrom(src => src.Id))
-            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId))
-            .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.GymOwnerId))
-            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.Name))
-            .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.Price))
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId ?? src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackageId))
+            .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId != null ? src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.GymOwnerId : Guid.Empty))
+            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId != null ? src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.Name : src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackage.Name))
+            .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId != null ? src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.Price : src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackage.Price))
             .ForMember(dest => dest.GymPtId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPtId))
-            .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.OrderItems.First().GymCourse.Description))
-            .ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.ImageUrl))
+            .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId != null ? src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.Description : src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackage.Description))
+            .ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId != null ? src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.ImageUrl : src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackage.ImageUrl))
             .ForMember(dest => dest.ExpirationDate, opt => opt.MapFrom(src => src.ExpirationDate))
             .ForMember(dest => dest.AvailableSessions, opt => opt.MapFrom(src => src.AvailableSessions))
-            .ForMember(dest => dest.GymPt, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPt));
+            .ForMember(dest => dest.Pt, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPtId != null ? src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPt : src.OrderItems.OrderByDescending(x => x.CreatedAt).First().FreelancePTPackage.Pt))
+            .ForMember(dest => dest.PackageType, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId != null ? PackageType.GymCourse : PackageType.FreelancePTPackage));
 
         CreateProjection<CustomerPurchased, CustomerPurchasedResponseDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))

--- a/FitBridge_Domain/Enums/GymCourses/PackageType.cs
+++ b/FitBridge_Domain/Enums/GymCourses/PackageType.cs
@@ -1,0 +1,10 @@
+using System;
+using FitBridge_Domain.Entities.Gyms;
+
+namespace FitBridge_Domain.Enums.GymCourses;
+
+public enum PackageType
+{
+    FreelancePTPackage,
+    GymCourse
+}

--- a/FitBridge_Infrastructure/Jobs/DistributeProfitJob.cs
+++ b/FitBridge_Infrastructure/Jobs/DistributeProfitJob.cs
@@ -14,10 +14,10 @@ public class DistributeProfitJob(IUnitOfWork _unitOfWork, ILogger<DistributeProf
 {
     public async Task Execute(IJobExecutionContext context)
     {
-        var customerPurchasedId = Guid.Parse(context.JobDetail.JobDataMap.GetString("customerPurchasedId")
-            ?? throw new NotFoundException($"{nameof(DistributeProfitJob)}_customerPurchasedId"));
-        _logger.LogInformation("DistributeProfitJob started for CustomerPurchased: {CustomerPurchasedId}", customerPurchasedId);
+        var orderItemId = Guid.Parse(context.JobDetail.JobDataMap.GetString("orderItemId")
+            ?? throw new NotFoundException($"{nameof(DistributeProfitJob)}_orderItemId"));
+        _logger.LogInformation("DistributeProfitJob started for OrderItem: {OrderItemId}", orderItemId);
 
-        await _transactionService.DistributeProfit(customerPurchasedId);
+        await _transactionService.DistributeProfit(orderItemId);
     }
 }

--- a/FitBridge_Infrastructure/Services/Jobs/ScheduleJobServices.cs
+++ b/FitBridge_Infrastructure/Services/Jobs/ScheduleJobServices.cs
@@ -11,11 +11,11 @@ public class ScheduleJobServices(ISchedulerFactory _schedulerFactory, ILogger<Sc
 {
     public async Task<bool> ScheduleProfitDistributionJob(ProfitJobScheduleDto profitJobScheduleDto)
     {
-        var jobKey = new JobKey($"ProfitDistribution_{profitJobScheduleDto.CustomerPurchasedId}", "ProfitDistribution");
-        var triggerKey = new TriggerKey($"ProfitDistribution_{profitJobScheduleDto.CustomerPurchasedId}_Trigger", "ProfitDistribution");
+        var jobKey = new JobKey($"ProfitDistribution_{profitJobScheduleDto.OrderItemId}", "ProfitDistribution");
+        var triggerKey = new TriggerKey($"ProfitDistribution_{profitJobScheduleDto.OrderItemId}_Trigger", "ProfitDistribution");
         var jobData = new JobDataMap
         {
-            { "customerPurchasedId", profitJobScheduleDto.CustomerPurchasedId.ToString() }
+            { "orderItemId", profitJobScheduleDto.OrderItemId.ToString() }
         };
         var job = JobBuilder.Create<DistributeProfitJob>()
         .WithIdentity(jobKey)
@@ -32,8 +32,8 @@ public class ScheduleJobServices(ISchedulerFactory _schedulerFactory, ILogger<Sc
         .ScheduleJob(job, trigger);
         
         _logger.LogInformation(
-        "Scheduled profit distribution job for CustomerPurchased {CustomerPurchasedId} at {TriggerTime}",
-        profitJobScheduleDto.CustomerPurchasedId, triggerTime);
+        "Scheduled profit distribution job for OrderItem {OrderItemId} at {TriggerTime}",
+        profitJobScheduleDto.OrderItemId, triggerTime);
         return true;
     }
 }


### PR DESCRIPTION
Replaces usage of CustomerPurchasedId with OrderItemId for profit distribution logic across DTOs, services, jobs, and mapping profiles. Adds PackageType enum and updates GymCoursesPtResponse to support both GymCourse and FreelancePTPackage. Improves error messages and ensures correct wallet and job scheduling updates.