### PR TITLE
#92 Add booking session start/end and activity set queries

### DIFF
--- a/FitBridge_API/Controllers/ActivitySetsController.cs
+++ b/FitBridge_API/Controllers/ActivitySetsController.cs
@@ -3,6 +3,7 @@ using FitBridge_API.Helpers.RequestHelpers;
 using FitBridge_Application.Dtos.ActivitySets;
 using FitBridge_Application.Features.ActivitySets.CreateActivitySet;
 using FitBridge_Application.Features.ActivitySets.GetActivitySetById;
+using FitBridge_Application.Features.ActivitySets.GetActivitySetBySessionId;
 using FitBridge_Application.Features.ActivitySets.UpdateActivityProgress;
 using FitBridge_Application.Features.ActivitySets.UpdateActivitySet;
 using MediatR;
@@ -23,7 +24,7 @@ public class ActivitySetsController(IMediator _mediator) : _BaseApiController
         var result = await _mediator.Send(command);
         return Ok(new BaseResponse<ActivitySetResponseDto>(StatusCodes.Status200OK.ToString(), "Activity set created successfully", result));
     }
-    
+
     /// <summary>
     /// Update activity set in session detail screen where pt create Session activity and activity set
     /// </summary>
@@ -53,5 +54,17 @@ public class ActivitySetsController(IMediator _mediator) : _BaseApiController
     {
         var result = await _mediator.Send(new GetActivitySetByIdQuery { Id = id });
         return Ok(new BaseResponse<ActivitySetResponseDto>(StatusCodes.Status200OK.ToString(), "Activity set retrieved successfully", result));
+    }
+
+    /// <summary>
+    /// Get all activity sets by session activity id
+    /// </summary>
+    /// <param name="sessionActivityId"></param>
+    /// <returns></returns>
+    [HttpGet("session-activity/{sessionActivityId}")]
+    public async Task<IActionResult> GetActivitySetsBySessionActivityId([FromRoute] Guid sessionActivityId)
+    {
+        var result = await _mediator.Send(new GetActivitySetsBySessionActivityIdQuery{ SessionActivityId = sessionActivityId });
+        return Ok(new BaseResponse<List<ActivitySetResponseDto>>(StatusCodes.Status200OK.ToString(), "Activity sets retrieved successfully", result));
     }
 }

--- a/FitBridge_API/Controllers/BookingsController.cs
+++ b/FitBridge_API/Controllers/BookingsController.cs
@@ -21,6 +21,8 @@ using FitBridge_Application.Features.Bookings.GetBookingRequest;
 using FitBridge_Application.Features.Bookings.RejectBookingRequest;
 using FitBridge_Application.Features.Bookings.GetTrainingResult;
 using FitBridge_Application.Features.Bookings.CreateBooking;
+using FitBridge_Application.Features.Bookings.StartBookingSession;
+using FitBridge_Application.Features.Bookings.EndBookingSession;
 
 namespace FitBridge_API.Controllers;
 
@@ -260,5 +262,19 @@ public class BookingsController(IMediator _mediator) : _BaseApiController
     {
         var result = await _mediator.Send(new GetTrainingResultQuery { BookingId = id });
         return Ok(new BaseResponse<TrainingResultResponseDto>(StatusCodes.Status200OK.ToString(), "Booking result retrieved successfully", result));
+    }
+
+    [HttpPost("start-booking-session")]
+    public async Task<IActionResult> StartBookingSession([FromBody] StartBookingSessionCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<DateTime>(StatusCodes.Status200OK.ToString(), "Booking session started successfully", result));
+    }
+
+    [HttpPost("end-booking-session")]
+    public async Task<IActionResult> EndBookingSession([FromBody] EndBookingSessionCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<DateTime>(StatusCodes.Status200OK.ToString(), "Booking session ended successfully", result));
     }
 }

--- a/FitBridge_Application/Dtos/ActivitySets/ActivitySetResponseDto.cs
+++ b/FitBridge_Application/Dtos/ActivitySets/ActivitySetResponseDto.cs
@@ -5,10 +5,11 @@ namespace FitBridge_Application.Dtos.ActivitySets;
 public class ActivitySetResponseDto
 {
     public Guid Id { get; set; }
-    public int? PlannedPracticeTime { get; set; }
+    public double? PlannedPracticeTime { get; set; }
     public double? WeightLifted { get; set; }
     public int? PlannedNumOfReps { get; set; }
     public int? NumOfReps { get; set; }
-    public int? PracticeTime { get; set; }
+    public double? PracticeTime { get; set; }
     public bool IsCompleted { get; set; }
+    public double? RestTime { get; set; }
 }

--- a/FitBridge_Application/Dtos/ActivitySets/ActivitySetUpdateRequestDto.cs
+++ b/FitBridge_Application/Dtos/ActivitySets/ActivitySetUpdateRequestDto.cs
@@ -8,6 +8,6 @@ public class ActivitySetUpdateRequestDto
     public double? WeightLifted { get; set; }
     public int? NumOfReps { get; set; }
     public bool IsCompleted { get; set; }
-    public int? PracticeTime { get; set; }
-    public int? RestTime { get; set; }
+    public double? PracticeTime { get; set; }
+    public double? RestTime { get; set; }
 }

--- a/FitBridge_Application/Dtos/SessionActivities/SessionPracticeContentDto.cs
+++ b/FitBridge_Application/Dtos/SessionActivities/SessionPracticeContentDto.cs
@@ -8,6 +8,7 @@ public class SessionPracticeContentDto
     public string note { get; set; }
     public string NutritionTip { get; set; }
     public string BookingName { get; set; }
-    
+    public DateTime? SessionStartTime { get; set; }
+    public DateTime? SessionEndTime { get; set; }
     public List<SessionActivityListDto> SessionActivities { get; set; } = new List<SessionActivityListDto>();
 }

--- a/FitBridge_Application/Features/ActivitySets/GetActivitySetBySessionId/GetActivitySetsBySessionActivityIdQuery.cs
+++ b/FitBridge_Application/Features/ActivitySets/GetActivitySetBySessionId/GetActivitySetsBySessionActivityIdQuery.cs
@@ -1,0 +1,10 @@
+using System;
+using FitBridge_Application.Dtos.ActivitySets;
+using MediatR;
+
+namespace FitBridge_Application.Features.ActivitySets.GetActivitySetBySessionId;
+
+public class GetActivitySetsBySessionActivityIdQuery : IRequest<List<ActivitySetResponseDto>>
+{
+    public Guid SessionActivityId { get; set; }
+}

--- a/FitBridge_Application/Features/ActivitySets/GetActivitySetBySessionId/GetActivitySetsBySessionActivityIdQueryHandler.cs
+++ b/FitBridge_Application/Features/ActivitySets/GetActivitySetBySessionId/GetActivitySetsBySessionActivityIdQueryHandler.cs
@@ -1,0 +1,19 @@
+using System;
+using FitBridge_Application.Dtos.ActivitySets;
+using FitBridge_Application.Interfaces.Repositories;
+using MediatR;
+using FitBridge_Domain.Entities.Trainings;
+using AutoMapper;
+using FitBridge_Application.Specifications.ActivitySets.GetActivitySetsBySessionActivityId;
+
+namespace FitBridge_Application.Features.ActivitySets.GetActivitySetBySessionId;
+
+public class GetActivitySetsBySessionActivityIdQueryHandler(IUnitOfWork unitOfWork, IMapper _mapper) : IRequestHandler<GetActivitySetsBySessionActivityIdQuery, List<ActivitySetResponseDto>>
+{   
+    public async Task<List<ActivitySetResponseDto>> Handle(GetActivitySetsBySessionActivityIdQuery request, CancellationToken cancellationToken)
+    {
+        var activitySets = await unitOfWork.Repository<ActivitySet>().GetAllWithSpecificationProjectedAsync<ActivitySetResponseDto>(new GetActivitySetsBySessionActivityIdSpecification(request.SessionActivityId), _mapper.ConfigurationProvider);
+        return activitySets.ToList();
+    }
+
+}

--- a/FitBridge_Application/Features/ActivitySets/UpdateActivityProgress/UpdateActivityProgressCommandHandler.cs
+++ b/FitBridge_Application/Features/ActivitySets/UpdateActivityProgress/UpdateActivityProgressCommandHandler.cs
@@ -21,6 +21,8 @@ public class UpdateActivityProgressCommandHandler(IUnitOfWork _unitOfWork, IMapp
         activitySet.NumOfReps = request.ActivitySet.NumOfReps;
         activitySet.PracticeTime = request.ActivitySet.PracticeTime;
         activitySet.RestTime = request.ActivitySet.RestTime;
+        _unitOfWork.Repository<ActivitySet>().Update(activitySet);
+        await _unitOfWork.CommitAsync();
         return _mapper.Map<ActivitySetResponseDto>(activitySet);
     }
 }

--- a/FitBridge_Application/Features/Bookings/EndBookingSession/EndBookingSessionCommand.cs
+++ b/FitBridge_Application/Features/Bookings/EndBookingSession/EndBookingSessionCommand.cs
@@ -1,0 +1,9 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.Bookings.EndBookingSession;
+
+public class EndBookingSessionCommand : IRequest<DateTime>
+{
+    public Guid BookingId { get; set; }
+}

--- a/FitBridge_Application/Features/Bookings/EndBookingSession/EndBookingSessionCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/EndBookingSession/EndBookingSessionCommandHandler.cs
@@ -1,0 +1,34 @@
+using System;
+using MediatR;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Enums.Trainings;
+namespace FitBridge_Application.Features.Bookings.EndBookingSession;
+
+public class EndBookingSessionCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<EndBookingSessionCommand, DateTime>
+{
+    public async Task<DateTime> Handle(EndBookingSessionCommand request, CancellationToken cancellationToken)
+    {
+        var booking = await _unitOfWork.Repository<Booking>().GetByIdAsync(request.BookingId);
+        if (booking == null)
+        {
+            throw new NotFoundException("Booking not found");
+        }
+        if (booking.SessionStartTime == null)
+        {
+            throw new BusinessException("Booking session not started");
+        }
+        if (booking.SessionEndTime != null)
+        {
+            throw new BusinessException("Booking session already ended");
+        }
+        booking.SessionEndTime = DateTime.UtcNow;
+        booking.SessionStatus = SessionStatus.Finished;
+        booking.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<Booking>().Update(booking);
+        await _unitOfWork.CommitAsync();
+        return booking.SessionEndTime.Value;
+    }
+
+}

--- a/FitBridge_Application/Features/Bookings/StartBookingSession/StartBookingSessionCommand.cs
+++ b/FitBridge_Application/Features/Bookings/StartBookingSession/StartBookingSessionCommand.cs
@@ -1,0 +1,9 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.Bookings.StartBookingSession;
+
+public class StartBookingSessionCommand : IRequest<DateTime>
+{
+    public Guid BookingId { get; set; }
+}

--- a/FitBridge_Application/Features/Bookings/StartBookingSession/StartBookingSessionCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/StartBookingSession/StartBookingSessionCommandHandler.cs
@@ -1,0 +1,29 @@
+using System;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Enums.Trainings;
+using MediatR;
+
+namespace FitBridge_Application.Features.Bookings.StartBookingSession;
+
+public class StartBookingSessionCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<StartBookingSessionCommand, DateTime>
+{
+    public async Task<DateTime> Handle(StartBookingSessionCommand request, CancellationToken cancellationToken)
+    {
+        var booking = await _unitOfWork.Repository<Booking>().GetByIdAsync(request.BookingId);
+        if (booking == null)
+        {
+            throw new NotFoundException("Booking not found");
+        }
+        if(booking.SessionStartTime != null)
+        {
+            throw new BusinessException("Booking session already started");
+        }
+        booking.SessionStartTime = DateTime.UtcNow;
+        booking.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<Booking>().Update(booking);
+        await _unitOfWork.CommitAsync();
+        return booking.SessionStartTime.Value;
+    }
+}

--- a/FitBridge_Application/Features/SessionActivities/SessionPracticeContent/SessionPracticeContentCommandHandler.cs
+++ b/FitBridge_Application/Features/SessionActivities/SessionPracticeContent/SessionPracticeContentCommandHandler.cs
@@ -36,6 +36,8 @@ public class SessionPracticeContentCommandHandler(IUnitOfWork _unitOfWork) : IRe
         }
         return new SessionPracticeContentDto {
         BookingId = request.BookingId,
+        SessionStartTime = sessionActivities.FirstOrDefault().Booking.SessionStartTime ?? null,
+        SessionEndTime = sessionActivities.FirstOrDefault().Booking.SessionEndTime ?? null,
         SessionActivities = sessionActivitiesDtos,
         BookingName = sessionActivities.FirstOrDefault()?.Booking.BookingName,
         note = sessionActivities.FirstOrDefault()?.Booking.Note,

--- a/FitBridge_Application/MappingProfiles/ActivitySetMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/ActivitySetMappingProfile.cs
@@ -11,9 +11,13 @@ public class ActivitySetMappingProfile : Profile
     public ActivitySetMappingProfile()
     {
         CreateMap<ActivitySetRequestDto, ActivitySet>()
-        .ForMember(dest => dest.PlannedNumOfReps, opt => opt.MapFrom(src => src.PlannedNumOfReps))
-        .ForMember(dest => dest.PlannedPracticeTime, opt => opt.MapFrom(src => src.PlannedPracticeTime));
-        CreateMap<ActivitySet, ActivitySetResponseDto>();
+        .ForMember(dest => dest.PlannedNumOfReps, opt => opt.MapFrom(src => src.PlannedNumOfReps ?? 0))
+        .ForMember(dest => dest.PlannedPracticeTime, opt => opt.MapFrom(src => src.PlannedPracticeTime ?? 0));
+        CreateMap<ActivitySet, ActivitySetResponseDto>()
+        .ForMember(dest => dest.PlannedNumOfReps, opt => opt.MapFrom(src => src.PlannedNumOfReps ?? 0))
+        .ForMember(dest => dest.PlannedPracticeTime, opt => opt.MapFrom(src => src.PlannedPracticeTime ?? 0))
+        .ForMember(dest => dest.NumOfReps, opt => opt.MapFrom(src => src.NumOfReps ?? 0))
+        .ForMember(dest => dest.PracticeTime, opt => opt.MapFrom(src => src.PracticeTime ?? 0));
         CreateMap<ActivitySetResponseDto, ActivitySet>();
         CreateMap<CreateActivitySetCommand, ActivitySet>();
     }

--- a/FitBridge_Application/Specifications/ActivitySets/GetActivitySetsBySessionActivityId/GetActivitySetsBySessionActivityIdSpecification.cs
+++ b/FitBridge_Application/Specifications/ActivitySets/GetActivitySetsBySessionActivityId/GetActivitySetsBySessionActivityIdSpecification.cs
@@ -1,0 +1,13 @@
+using System;
+using FitBridge_Application.Interfaces.Specifications;
+using FitBridge_Domain.Entities.Trainings;
+
+namespace FitBridge_Application.Specifications.ActivitySets.GetActivitySetsBySessionActivityId;
+
+public class GetActivitySetsBySessionActivityIdSpecification : BaseSpecification<ActivitySet>
+{
+    public GetActivitySetsBySessionActivityIdSpecification(Guid sessionActivityId) : base(x => x.SessionActivityId == sessionActivityId)
+    {
+        AddInclude(x => x.SessionActivity);
+    }
+}

--- a/FitBridge_Domain/Entities/Trainings/Booking.cs
+++ b/FitBridge_Domain/Entities/Trainings/Booking.cs
@@ -28,9 +28,8 @@ public class Booking : BaseEntity
     public string? Note { get; set; }
 
     public string? NutritionTip { get; set; }
-    public DateTime? SessionStartTime { get; set; }
+    public DateTime? SessionStartTime { get; set; } 
     public DateTime? SessionEndTime { get; set; }
-
     public PTGymSlot? PTGymSlot { get; set; }
 
     public ApplicationUser Customer { get; set; }

--- a/FitBridge_Domain/Enums/Bookings/BookingStatus.cs
+++ b/FitBridge_Domain/Enums/Bookings/BookingStatus.cs
@@ -1,0 +1,8 @@
+namespace FitBridge_Domain.Enums.Bookings;
+
+public enum BookingStatus
+{
+    NotStarted,
+    InProgress,
+    Finished,
+}

--- a/FitBridge_Infrastructure/Configurations/BookingConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/BookingConfiguration.cs
@@ -18,7 +18,9 @@ public class BookingConfiguration : IEntityTypeConfiguration<Booking>
         builder.Property(e => e.BookingName).IsRequired(false);
         builder.Property(e => e.Note).IsRequired(false);
         builder.Property(e => e.NutritionTip).IsRequired(false);
-        builder.Property(e => e.SessionStatus).IsRequired(true).HasDefaultValue(SessionStatus.Booked);
+        builder.Property(e => e.SessionStatus).IsRequired(true)
+        .HasConversion(convertToProviderExpression: s => s.ToString(), convertFromProviderExpression: s => Enum.Parse<SessionStatus>(s))
+        .HasDefaultValue(SessionStatus.Booked);
         builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);


### PR DESCRIPTION
Introduces endpoints and handlers for starting and ending booking sessions, including session start/end time tracking. Adds query and specification to fetch activity sets by session activity ID. Updates DTOs and mapping profiles to support new fields and type changes for practice/rest times. Refactors related command handlers and configuration for session status.