### PR TITLE
#92 Add job cancellation for finished booking sessions

### DIFF
--- a/FitBridge_Application/Features/Bookings/EndBookingSession/EndBookingSessionCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/EndBookingSession/EndBookingSessionCommandHandler.cs
@@ -8,7 +8,7 @@ using FitBridge_Application.Interfaces.Services;
 using FitBridge_Application.Dtos.Jobs;
 namespace FitBridge_Application.Features.Bookings.EndBookingSession;
 
-public class EndBookingSessionCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<EndBookingSessionCommand, DateTime>
+public class EndBookingSessionCommandHandler(IUnitOfWork _unitOfWork, IScheduleJobServices _scheduleJobServices) : IRequestHandler<EndBookingSessionCommand, DateTime>
 {
     public async Task<DateTime> Handle(EndBookingSessionCommand request, CancellationToken cancellationToken)
     {
@@ -30,6 +30,7 @@ public class EndBookingSessionCommandHandler(IUnitOfWork _unitOfWork) : IRequest
         booking.UpdatedAt = DateTime.UtcNow;
         _unitOfWork.Repository<Booking>().Update(booking);
         await _unitOfWork.CommitAsync();
+        await _scheduleJobServices.CancelScheduleJob($"FinishedBookingSession_{request.BookingId}", "FinishedBookingSession");
         return booking.SessionEndTime.Value;
     }
 

--- a/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
+++ b/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
@@ -8,4 +8,5 @@ public interface IScheduleJobServices
     Task<bool> ScheduleProfitDistributionJob(ProfitJobScheduleDto profitJobScheduleDto);
 
     Task<bool> ScheduleFinishedBookingSession(FinishedBookingSessionJobScheduleDto finishedBookingSessionJobScheduleDto);
+    Task<bool> CancelScheduleJob(string jobName, string jobGroup);
 }


### PR DESCRIPTION
Introduces CancelScheduleJob to IScheduleJobServices and implements it in ScheduleJobServices. EndBookingSessionCommandHandler now cancels the scheduled job when a booking session ends. Also updates StartBookingSessionCommandHandler to include related entities and corrects job scheduling trigger time calculation.