### PR TITLE
#92 Allow FreelancePT role to cancel bookings

### DIFF
--- a/FitBridge_API/Controllers/BookingsController.cs
+++ b/FitBridge_API/Controllers/BookingsController.cs
@@ -29,7 +29,7 @@ namespace FitBridge_API.Controllers;
 public class BookingsController(IMediator _mediator) : _BaseApiController
 {
     [HttpPost("cancel-booking")]
-    [Authorize(Roles = ProjectConstant.UserRoles.Customer + "," + ProjectConstant.UserRoles.GymPT)]
+    [Authorize(Roles = ProjectConstant.UserRoles.Customer + "," + ProjectConstant.UserRoles.GymPT + "," + ProjectConstant.UserRoles.FreelancePT)]
     public async Task<IActionResult> CancelBooking([FromBody] CancelGymPtBookingCommand command)
     {
         var result = await _mediator.Send(command);


### PR DESCRIPTION
Added FreelancePT to the list of authorized roles for the cancel-booking endpoint, enabling users with this role to cancel bookings.