### PR TITLE
#92 Add SessionReportDto and refactor training result logic

### DIFF
--- a/FitBridge_API/Controllers/BookingsController.cs
+++ b/FitBridge_API/Controllers/BookingsController.cs
@@ -261,7 +261,7 @@ public class BookingsController(IMediator _mediator) : _BaseApiController
     public async Task<IActionResult> GetTrainingResult([FromRoute] Guid id)
     {
         var result = await _mediator.Send(new GetTrainingResultQuery { BookingId = id });
-        return Ok(new BaseResponse<TrainingResultResponseDto>(StatusCodes.Status200OK.ToString(), "Booking result retrieved successfully", result));
+        return Ok(new BaseResponse<SessionReportDto>(StatusCodes.Status200OK.ToString(), "Booking result retrieved successfully", result));
     }
 
     /// <summary>

--- a/FitBridge_Application/Dtos/Bookings/SessionReportDto.cs
+++ b/FitBridge_Application/Dtos/Bookings/SessionReportDto.cs
@@ -1,0 +1,92 @@
+using System;
+using FitBridge_Domain.Enums.SessionActivities;
+using FitBridge_Domain.Enums.Trainings;
+
+namespace FitBridge_Application.Dtos.Bookings;
+
+public class SessionReportDto
+{
+    public Guid BookingId { get; set; }
+    public string? SessionName { get; set; }
+    public DateOnly DateTraining { get; set; }
+    public TimeOnly? PlannedStartTime { get; set; }
+    public TimeOnly? PlannedEndTime { get; set; }
+    public DateTime? ActualStartTime { get; set; }
+    public DateTime? ActualEndTime { get; set; }
+
+    //Overview
+    public SessionTotalsDto SessionTotalSummary { get; set; } = new(); // có % hoàn thành
+    public List<ActivityType> ActivityTypesPerformed { get; set; } = new(); // Danh sách các loại hoạt động đã thực hiện
+
+    // Chi tiết
+    public List<ActivitySummaryDto> ActivitiesSummary { get; set; } = new();     // mỗi bài tập
+    public List<MuscleGroupAggregateDto> MuscleGroupAggregates { get; set; } = new();
+
+    public string? Note { get; set; }
+    public string? NutritionTip { get; set; }
+
+
+}
+
+public class SessionTotalsDto
+{
+    public int SessionActivityCount { get; set; }
+
+    //Set/Reps toàn buổi
+    public int TotalCompletedSets { get; set; }
+    public int TotalCompletedReps { get; set; }
+    public int TotalCompletedDistanceMeters { get; set; }
+
+    public int TotalPlannedDistanceMeters { get; set; }
+    public double TotalPlannedPracticeTimeSec { get; set; } // Tổng thời gian tập luyện của các Reps
+
+    //Planned vs actual sets
+    public int PlannedSets { get; set; }
+    public int PlannedReps { get; set; }
+    public double? CompletionPercentage { get; set; }
+
+    public double TotalCompletedPracticeTimeSec { get; set; }
+    public int TotalRestTimeSec { get; set; } // Tổng thời gian nghỉ giữa các reps
+}
+
+public class ActivitySummaryDto
+{
+    public Guid SessionActivityId { get; set; }
+    public string? ActivityName { get; set; }
+    public ActivityType ActivityType { get; set; }
+    public MuscleGroupEnum MuscleGroup { get; set; }
+
+    //Kết cấu bài
+    public int CompletedReps { get; set; }
+    public int PlannedSets { get; set; }
+    public int PlannedReps { get; set; }
+    public int PlannedDistanceMeters { get; set; }
+    public double PlannedPracticeTimeSeconds { get; set; }
+    public int CompletedDistanceMeters { get; set; }
+    public double CompletedPracticeTimeSeconds { get; set; }
+    public int CompletedSets { get; set; }
+    public int? LongestDistanceMeters { get; set; }
+    public int? ShortestDistanceMeters { get; set; }
+
+    public double? LongestPracticeTimeSeconds { get; set; }
+    public double? ShortestPracticeTimeSeconds { get; set; }
+    public double? HeaviestWeightLifted { get; set; } = 0.0;
+    public double? LightestWeightLifted { get; set; } = 0.0;
+
+}
+
+public class MuscleGroupAggregateDto
+{
+    public MuscleGroupEnum MuscleGroup { get; set; }
+    public int SessionActivitiesCount { get; set; }
+    public int TotalSetsCompleted { get; set; }
+    public int TotalRepsCompleted { get; set; }
+    public double VolumeActualWeightLifted { get; set; }
+    public double VolumePlannedWeightLifted { get; set; }
+    public double PracticeTimeActualSeconds { get; set; }
+    public double PracticeTimePlannedSeconds { get; set; }
+    public int DistancePlannedMeters { get; set; }
+    public int DistanceActualMeters { get; set; }
+}
+
+

--- a/FitBridge_Application/Dtos/SessionActivities/SessionActivityResponseDto.cs
+++ b/FitBridge_Application/Dtos/SessionActivities/SessionActivityResponseDto.cs
@@ -1,6 +1,7 @@
 using System;
 using FitBridge_Application.Dtos.ActivitySets;
 using FitBridge_Domain.Enums.ActivitySets;
+using FitBridge_Domain.Enums.SessionActivities;
 using FitBridge_Domain.Enums.Trainings;
 
 namespace FitBridge_Application.Dtos.SessionActivities;
@@ -12,7 +13,7 @@ public class SessionActivityResponseDto
     public ActivitySetType ActivitySetType { get; set; }
 
     public string ActivityName { get; set; }
-    public List<string> MuscleGroups { get; set; } = new List<string>();
+    public MuscleGroupEnum MuscleGroup { get; set; }
 
     public Guid BookingId { get; set; }
     public ICollection<ActivitySetResponseDto> ActivitySets { get; set; } = new List<ActivitySetResponseDto>();

--- a/FitBridge_Application/Features/Bookings/GetTrainingResult/GetTrainingResultQuery.cs
+++ b/FitBridge_Application/Features/Bookings/GetTrainingResult/GetTrainingResultQuery.cs
@@ -4,7 +4,7 @@ using MediatR;
 
 namespace FitBridge_Application.Features.Bookings.GetTrainingResult;
 
-public class GetTrainingResultQuery : IRequest<TrainingResultResponseDto>
+public class GetTrainingResultQuery : IRequest<SessionReportDto>
 {
     public Guid BookingId { get; set; }
 }

--- a/FitBridge_Application/Features/Bookings/GetTrainingResult/GetTrainingResultQueryHandler.cs
+++ b/FitBridge_Application/Features/Bookings/GetTrainingResult/GetTrainingResultQueryHandler.cs
@@ -5,12 +5,13 @@ using FitBridge_Application.Interfaces.Repositories;
 using AutoMapper;
 using FitBridge_Domain.Entities.Trainings;
 using FitBridge_Domain.Exceptions;
+using Microsoft.Net.Http.Headers;
 
 namespace FitBridge_Application.Features.Bookings.GetTrainingResult;
 
-public class GetTrainingResultQueryHandler(IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<GetTrainingResultQuery, TrainingResultResponseDto>
+public class GetTrainingResultQueryHandler(IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<GetTrainingResultQuery, SessionReportDto>
 {
-    public async Task<TrainingResultResponseDto> Handle(GetTrainingResultQuery request, CancellationToken cancellationToken)
+    public async Task<SessionReportDto> Handle(GetTrainingResultQuery request, CancellationToken cancellationToken)
     {
         var bookingEntity = await _unitOfWork.Repository<Booking>().GetByIdAsync(request.BookingId, false, new List<string>
         {
@@ -22,7 +23,39 @@ public class GetTrainingResultQueryHandler(IUnitOfWork _unitOfWork, IMapper _map
         {
             throw new NotFoundException("Booking not found");
         }
-        var trainingResult = _mapper.Map<TrainingResultResponseDto>(bookingEntity);
+        var trainingResult = _mapper.Map<SessionReportDto>(bookingEntity);
+        trainingResult.SessionTotalSummary.CompletionPercentage = trainingResult.SessionTotalSummary.PlannedReps == 0 && trainingResult.SessionTotalSummary.TotalPlannedDistanceMeters == 0 && trainingResult.SessionTotalSummary.TotalPlannedPracticeTimeSec == 0 ? 0 : Math.Round((double)(trainingResult.SessionTotalSummary.TotalCompletedReps
+        + trainingResult.SessionTotalSummary.TotalCompletedDistanceMeters
+        + trainingResult.SessionTotalSummary.TotalCompletedPracticeTimeSec
+        ) / (
+            trainingResult.SessionTotalSummary.PlannedReps + trainingResult.SessionTotalSummary.TotalPlannedDistanceMeters + trainingResult.SessionTotalSummary.TotalPlannedPracticeTimeSec
+            ) * 100, 1, MidpointRounding.AwayFromZero);
+        var muscleGroups = bookingEntity.SessionActivities.Select(x => x.MuscleGroup).Distinct().ToList();
+        foreach (var muscleGroup in muscleGroups)
+        {
+            var muscleGroupAggregate = new MuscleGroupAggregateDto();
+            foreach (var sessionActivity in bookingEntity.SessionActivities.Where(x => x.MuscleGroup == muscleGroup))
+            {
+                muscleGroupAggregate.SessionActivitiesCount++;
+                muscleGroupAggregate.MuscleGroup = muscleGroup;
+
+                foreach (var activitySet in sessionActivity.ActivitySets)
+                {
+                    if (activitySet.IsCompleted)
+                    {
+                        muscleGroupAggregate.TotalSetsCompleted++;
+                        muscleGroupAggregate.TotalRepsCompleted += activitySet.NumOfReps ?? 0;
+                    }
+                    muscleGroupAggregate.VolumeActualWeightLifted += activitySet.IsCompleted ? (activitySet.WeightLifted ?? 0) * (activitySet.NumOfReps ?? 0) : 0; 
+                    muscleGroupAggregate.VolumePlannedWeightLifted += (activitySet.WeightLifted ?? 0) * (activitySet.PlannedNumOfReps ?? 0);
+                    muscleGroupAggregate.DistanceActualMeters += activitySet.IsCompleted ? activitySet.ActualDistance ?? 0 : 0;
+                    muscleGroupAggregate.DistancePlannedMeters += activitySet.PlannedDistance ?? 0;
+                    muscleGroupAggregate.PracticeTimeActualSeconds += activitySet.IsCompleted ? activitySet.PracticeTime ?? 0 : 0;
+                    muscleGroupAggregate.PracticeTimePlannedSeconds += activitySet.PlannedPracticeTime ?? 0;
+                }
+            }
+            trainingResult.MuscleGroupAggregates.Add(muscleGroupAggregate);
+        }
         return trainingResult;
     }
 

--- a/FitBridge_Application/Features/SessionActivities/CreateSessionActivityCommand.cs
+++ b/FitBridge_Application/Features/SessionActivities/CreateSessionActivityCommand.cs
@@ -15,6 +15,6 @@ public class CreateSessionActivityCommand : IRequest<SessionActivityResponseDto>
     public ActivityType ActivityType { get; set; }
     public ActivitySetType ActivitySetType { get; set; }
     public string ActivityName { get; set; }
-    public List<MuscleGroupEnum> MuscleGroups { get; set; } = new List<MuscleGroupEnum>();
+    public MuscleGroupEnum MuscleGroup { get; set; }
     public List<ActivitySetRequestDto> ActivitySets { get; set; } = new List<ActivitySetRequestDto>();
 }

--- a/FitBridge_Application/MappingProfiles/BookingMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/BookingMappingProfile.cs
@@ -134,11 +134,55 @@ public class BookingMappingProfile : Profile
         .ForMember(dest => dest.Notes, opt => opt.MapFrom(src => src.Note))
         .ForMember(dest => dest.PtName, opt => opt.MapFrom(src => src.PtId != null ? src.Pt.FullName : null))
         .ForMember(dest => dest.PtAvatarUrl, opt => opt.MapFrom(src => src.PtId != null ? src.Pt.AvatarUrl : null))
-        .ForPath(dest => dest.RepsProgress.RepsCompleted, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? a.NumOfReps ?? 0 : 0))))   
+        .ForPath(dest => dest.RepsProgress.RepsCompleted, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? a.NumOfReps ?? 0 : 0))))
         .ForPath(dest => dest.WeightLiftedProgress.WeightLiftedCompleted, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? (a.WeightLifted ?? 0) * (a.NumOfReps ?? 0) : 0))))
         .ForPath(dest => dest.RepsProgress.RepsPlan, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.PlannedNumOfReps ?? 0))))
         .ForPath(dest => dest.WeightLiftedProgress.WeightLiftedPlan, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => (a.WeightLifted ?? 0) * (a.PlannedNumOfReps ?? 0)))))
         .ForPath(dest => dest.PracticeTimeProgress.PracticeTimeCompleted, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? a.PracticeTime ?? 0 : 0))))
         .ForPath(dest => dest.PracticeTimeProgress.PracticeTimePlan, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.PlannedPracticeTime ?? 0))));
+
+        CreateMap<Booking, SessionReportDto>()
+        .ForMember(dest => dest.BookingId, opt => opt.MapFrom(src => src.Id))
+        .ForMember(dest => dest.SessionName, opt => opt.MapFrom(src => src.BookingName))
+        .ForMember(dest => dest.DateTraining, opt => opt.MapFrom(src => src.BookingDate))
+        .ForMember(dest => dest.PlannedStartTime, opt => opt.MapFrom(src => src.PtFreelanceStartTime))
+        .ForMember(dest => dest.PlannedEndTime, opt => opt.MapFrom(src => src.PtFreelanceEndTime))
+        .ForMember(dest => dest.ActualStartTime, opt => opt.MapFrom(src => src.SessionStartTime))
+        .ForMember(dest => dest.ActualEndTime, opt => opt.MapFrom(src => src.SessionEndTime))
+        .ForMember(dest => dest.Note, opt => opt.MapFrom(src => src.Note))
+        .ForMember(dest => dest.NutritionTip, opt => opt.MapFrom(src => src.NutritionTip))
+        .ForPath(dest => dest.SessionTotalSummary.SessionActivityCount, opt => opt.MapFrom(src => src.SessionActivities.Count))
+        .ForPath(dest => dest.SessionTotalSummary.TotalCompletedSets, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Count(a => a.IsCompleted))))
+        .ForPath(dest => dest.SessionTotalSummary.TotalCompletedReps, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? a.NumOfReps ?? 0 : 0))))
+        .ForPath(dest => dest.SessionTotalSummary.TotalPlannedPracticeTimeSec, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.PlannedPracticeTime ?? 0))))
+        .ForPath(dest => dest.SessionTotalSummary.TotalCompletedPracticeTimeSec, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? a.PracticeTime ?? 0 : 0))))
+        .ForPath(dest => dest.SessionTotalSummary.TotalRestTimeSec, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? a.RestTime ?? 0 : 0))))
+        .ForPath(dest => dest.SessionTotalSummary.PlannedSets, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Count)))
+        .ForPath(dest => dest.SessionTotalSummary.PlannedReps, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.PlannedNumOfReps ?? 0))))
+        .ForPath(dest => dest.SessionTotalSummary.TotalPlannedDistanceMeters, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.PlannedDistance ?? 0))))
+        .ForPath(dest => dest.SessionTotalSummary.TotalCompletedDistanceMeters, opt => opt.MapFrom(src => src.SessionActivities.Sum(s => s.ActivitySets.Sum(a => a.IsCompleted ? a.ActualDistance ?? 0 : 0))))
+        .ForMember(dest => dest.ActivityTypesPerformed, opt => opt.MapFrom(src => src.SessionActivities.Select(s => s.ActivityType).Distinct().ToList()))
+        .ForPath(dest => dest.ActivitiesSummary, opt => opt.MapFrom(src => src.SessionActivities.Select(s => new ActivitySummaryDto
+        {
+            SessionActivityId = s.Id,
+            ActivityName = s.ActivityName,
+            ActivityType = s.ActivityType,
+            MuscleGroup = s.MuscleGroup,
+            CompletedSets = s.ActivitySets.Count(a => a.IsCompleted),
+            CompletedReps = s.ActivitySets.Sum(a => a.IsCompleted ? a.NumOfReps ?? 0 : 0),
+            PlannedSets = s.ActivitySets.Count,
+            PlannedReps = s.ActivitySets.Sum(a => a.PlannedNumOfReps ?? 0),
+            HeaviestWeightLifted = s.ActivitySets.Max(a => a.IsCompleted ? a.WeightLifted ?? 0 : 0),
+            LightestWeightLifted = s.ActivitySets.Min(a => a.IsCompleted ? a.WeightLifted ?? 0 : 0),
+            LongestDistanceMeters = s.ActivitySets.Max(a => a.IsCompleted ? a.ActualDistance ?? 0 : 0),
+            ShortestDistanceMeters = s.ActivitySets.Min(a => a.IsCompleted ? a.ActualDistance ?? 0 : 0),
+            LongestPracticeTimeSeconds = s.ActivitySets.Max(a => a.IsCompleted ? a.PracticeTime ?? 0 : 0),
+            ShortestPracticeTimeSeconds = s.ActivitySets.Min(a => a.IsCompleted ? a.PracticeTime ?? 0 : 0),
+            PlannedDistanceMeters = s.ActivitySets.Sum(a => a.PlannedDistance ?? 0),
+            PlannedPracticeTimeSeconds = s.ActivitySets.Sum(a => a.PlannedPracticeTime ?? 0),
+            CompletedDistanceMeters = s.ActivitySets.Sum(a => a.IsCompleted ? a.ActualDistance ?? 0 : 0),
+            CompletedPracticeTimeSeconds = s.ActivitySets.Sum(a => a.IsCompleted ? a.PracticeTime ?? 0 : 0),
+
+        }).ToList()));
     }
 }


### PR DESCRIPTION
Introduces SessionReportDto to provide a detailed session report for bookings. Refactors GetTrainingResultQuery and related handler to use SessionReportDto instead of TrainingResultResponseDto, updates mapping profiles, and changes session activity muscle group handling from a list to a single enum for consistency.