### PR TITLE
#92 Add distance fields to activity sets and delete session activity

### DIFF
--- a/FitBridge_API/Controllers/SessionActivitiesController.cs
+++ b/FitBridge_API/Controllers/SessionActivitiesController.cs
@@ -3,6 +3,7 @@ using FitBridge_API.Helpers.RequestHelpers;
 using FitBridge_Application.Commons.Constants;
 using FitBridge_Application.Dtos.SessionActivities;
 using FitBridge_Application.Features.SessionActivities;
+using FitBridge_Application.Features.SessionActivities.DeleteSessionActivity;
 using FitBridge_Application.Features.SessionActivities.GetSessionActivityById;
 using FitBridge_Application.Features.SessionActivities.SessionPracticeContent;
 using FitBridge_Application.Features.SessionActivities.UpdateSessionActivity;
@@ -58,5 +59,12 @@ public class SessionActivitiesController(IMediator _mediator) : _BaseApiControll
     {
         var result = await _mediator.Send(new SessionPracticeContentCommand { BookingId = bookingId });
         return Ok(new BaseResponse<SessionPracticeContentDto>(StatusCodes.Status200OK.ToString(), "Practice content retrieved successfully", result));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteSessionActivity([FromRoute] Guid id)
+    {
+        var result = await _mediator.Send(new DeleteSessionActivityCommand { Id = id });
+        return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Session activity deleted successfully", result));
     }
 }

--- a/FitBridge_Application/Dtos/ActivitySets/ActivitySetRequestDto.cs
+++ b/FitBridge_Application/Dtos/ActivitySets/ActivitySetRequestDto.cs
@@ -7,4 +7,5 @@ public class ActivitySetRequestDto
     public int? PlannedNumOfReps { get; set; }
     public double? WeightLifted { get; set; }
     public double? PlannedPracticeTime { get; set; }
+    public int? PlannedDistance { get; set; }
 }

--- a/FitBridge_Application/Dtos/ActivitySets/ActivitySetResponseDto.cs
+++ b/FitBridge_Application/Dtos/ActivitySets/ActivitySetResponseDto.cs
@@ -8,7 +8,9 @@ public class ActivitySetResponseDto
     public double? PlannedPracticeTime { get; set; }
     public double? WeightLifted { get; set; }
     public int? PlannedNumOfReps { get; set; }
+    public int? PlannedDistance { get; set; }
     public int? NumOfReps { get; set; }
+    public int? ActualDistance { get; set; }
     public double? PracticeTime { get; set; }
     public bool IsCompleted { get; set; }
     public double? RestTime { get; set; }

--- a/FitBridge_Application/Dtos/ActivitySets/ActivitySetUpdateRequestDto.cs
+++ b/FitBridge_Application/Dtos/ActivitySets/ActivitySetUpdateRequestDto.cs
@@ -9,5 +9,6 @@ public class ActivitySetUpdateRequestDto
     public int? NumOfReps { get; set; }
     public bool IsCompleted { get; set; }
     public double? PracticeTime { get; set; }
+    public int? ActualDistance { get; set; }
     public double? RestTime { get; set; }
 }

--- a/FitBridge_Application/Features/ActivitySets/CreateActivitySet/CreateActivitySetCommand.cs
+++ b/FitBridge_Application/Features/ActivitySets/CreateActivitySet/CreateActivitySetCommand.cs
@@ -10,4 +10,5 @@ public class CreateActivitySetCommand : IRequest<ActivitySetResponseDto>
     public double? WeightLifted { get; set; }
     public int? NumOfReps { get; set; }
     public double? PlannedPracticeTime { get; set; }
+    public int? PlannedDistance { get; set; }
 }

--- a/FitBridge_Application/Features/ActivitySets/CreateActivitySet/CreateActivitySetCommandHandler.cs
+++ b/FitBridge_Application/Features/ActivitySets/CreateActivitySet/CreateActivitySetCommandHandler.cs
@@ -22,7 +22,8 @@ public class CreateActivitySetCommandHandler(IUnitOfWork unitOfWork, IMapper map
             SessionActivityId = request.SessionActivityId,
             WeightLifted = request.WeightLifted ?? 0,
             PlannedNumOfReps = request.NumOfReps ?? 0,
-            PlannedPracticeTime = request.PlannedPracticeTime ?? 0.0
+            PlannedPracticeTime = request.PlannedPracticeTime ?? 0.0,
+            PlannedDistance = request.PlannedDistance ?? 0,
         };
         unitOfWork.Repository<ActivitySet>().Insert(activitySet);
         await unitOfWork.CommitAsync();

--- a/FitBridge_Application/Features/ActivitySets/UpdateActivityProgress/UpdateActivityProgressCommandHandler.cs
+++ b/FitBridge_Application/Features/ActivitySets/UpdateActivityProgress/UpdateActivityProgressCommandHandler.cs
@@ -17,10 +17,11 @@ public class UpdateActivityProgressCommandHandler(IUnitOfWork _unitOfWork, IMapp
             throw new NotFoundException(nameof(ActivitySet));
         }
         activitySet.IsCompleted = request.ActivitySet.IsCompleted;
-        activitySet.WeightLifted = request.ActivitySet.WeightLifted;
-        activitySet.NumOfReps = request.ActivitySet.NumOfReps;
-        activitySet.PracticeTime = request.ActivitySet.PracticeTime;
-        activitySet.RestTime = request.ActivitySet.RestTime;
+        activitySet.WeightLifted = request.ActivitySet.WeightLifted ?? activitySet.WeightLifted;
+        activitySet.NumOfReps = request.ActivitySet.NumOfReps ?? activitySet.NumOfReps;
+        activitySet.PracticeTime = request.ActivitySet.PracticeTime ?? activitySet.PracticeTime;
+        activitySet.RestTime = request.ActivitySet.RestTime ?? activitySet.RestTime;
+        activitySet.ActualDistance = request.ActivitySet.ActualDistance ?? activitySet.ActualDistance;
         _unitOfWork.Repository<ActivitySet>().Update(activitySet);
         await _unitOfWork.CommitAsync();
         return _mapper.Map<ActivitySetResponseDto>(activitySet);

--- a/FitBridge_Application/Features/ActivitySets/UpdateActivitySet/UpdateActivitySetCommand.cs
+++ b/FitBridge_Application/Features/ActivitySets/UpdateActivitySet/UpdateActivitySetCommand.cs
@@ -8,5 +8,7 @@ public class UpdateActivitySetCommand : IRequest<ActivitySetResponseDto>
 {
     public Guid ActivitySetId { get; set; }
     public double? WeightLifted { get; set; }
-    public int? NumOfReps { get; set; }
+    public int? PlannedNumOfReps { get; set; }
+    public int? PlannedDistance { get; set; }
+    public double? PlannedPracticeTime { get; set; }
 }

--- a/FitBridge_Application/Features/ActivitySets/UpdateActivitySet/UpdateActivitySetCommandHandler.cs
+++ b/FitBridge_Application/Features/ActivitySets/UpdateActivitySet/UpdateActivitySetCommandHandler.cs
@@ -22,7 +22,10 @@ public class UpdateActivitySetCommandHandler(IUnitOfWork unitOfWork, IMapper map
             throw new BusinessException("Activity set already completed, cannot update");
         }
         activitySet.WeightLifted = request.WeightLifted ?? activitySet.WeightLifted;
-        activitySet.NumOfReps = request.NumOfReps ?? activitySet.NumOfReps;
+        activitySet.PlannedNumOfReps = request.PlannedNumOfReps ?? activitySet.PlannedNumOfReps;
+        activitySet.ActualDistance = request.PlannedDistance ?? activitySet.ActualDistance;
+        activitySet.PlannedPracticeTime = request.PlannedPracticeTime ?? activitySet.PlannedPracticeTime;
+        activitySet.PlannedDistance = request.PlannedDistance ?? activitySet.PlannedDistance;
         activitySet.UpdatedAt = DateTime.UtcNow;
         unitOfWork.Repository<ActivitySet>().Update(activitySet);
         await unitOfWork.CommitAsync();

--- a/FitBridge_Application/Features/SessionActivities/DeleteSessionActivity/DeleteSessionActivityCommand.cs
+++ b/FitBridge_Application/Features/SessionActivities/DeleteSessionActivity/DeleteSessionActivityCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace FitBridge_Application.Features.SessionActivities.DeleteSessionActivity;
+
+public class DeleteSessionActivityCommand : IRequest<bool>
+{
+    public Guid Id { get; set; }
+}

--- a/FitBridge_Application/Features/SessionActivities/DeleteSessionActivity/DeleteSessionActivityCommandHandler.cs
+++ b/FitBridge_Application/Features/SessionActivities/DeleteSessionActivity/DeleteSessionActivityCommandHandler.cs
@@ -1,0 +1,26 @@
+using System;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Exceptions;
+using MediatR;
+
+namespace FitBridge_Application.Features.SessionActivities.DeleteSessionActivity;
+
+public class DeleteSessionActivityCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<DeleteSessionActivityCommand, bool>
+{
+    public async Task<bool> Handle(DeleteSessionActivityCommand request, CancellationToken cancellationToken)
+    {
+        var sessionActivity = await _unitOfWork.Repository<SessionActivity>().GetByIdAsync(request.Id, false, new List<string> { "ActivitySets" });
+        if (sessionActivity == null)
+        {
+            throw new NotFoundException("Session activity not found");
+        }
+        if(sessionActivity.ActivitySets.Count > 0)
+        {
+            throw new BusinessException("Cannot delete session activity with activity sets. Please clear the activity sets first.");
+        }
+        _unitOfWork.Repository<SessionActivity>().Delete(sessionActivity);
+        await _unitOfWork.CommitAsync();
+        return true;
+    }
+}

--- a/FitBridge_Application/MappingProfiles/ActivitySetMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/ActivitySetMappingProfile.cs
@@ -12,7 +12,8 @@ public class ActivitySetMappingProfile : Profile
     {
         CreateMap<ActivitySetRequestDto, ActivitySet>()
         .ForMember(dest => dest.PlannedNumOfReps, opt => opt.MapFrom(src => src.PlannedNumOfReps ?? 0))
-        .ForMember(dest => dest.PlannedPracticeTime, opt => opt.MapFrom(src => src.PlannedPracticeTime ?? 0));
+        .ForMember(dest => dest.PlannedPracticeTime, opt => opt.MapFrom(src => src.PlannedPracticeTime ?? 0))
+        .ForMember(dest => dest.PlannedDistance, opt => opt.MapFrom(src => src.PlannedDistance ?? 0));
         CreateMap<ActivitySet, ActivitySetResponseDto>()
         .ForMember(dest => dest.PlannedNumOfReps, opt => opt.MapFrom(src => src.PlannedNumOfReps ?? 0))
         .ForMember(dest => dest.PlannedPracticeTime, opt => opt.MapFrom(src => src.PlannedPracticeTime ?? 0))

--- a/FitBridge_Infrastructure/Configurations/WithdrawalRequestConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/WithdrawalRequestConfiguration.cs
@@ -14,11 +14,11 @@ public class WithdrawalRequestConfiguration : IEntityTypeConfiguration<Withdrawa
         builder.Property(e => e.Status).IsRequired(true)
         .HasConversion(convertToProviderExpression: s => s.ToString(), convertFromProviderExpression: s => Enum.Parse<WithdrawalRequestStatus>(s));
         builder.Property(e => e.Amount).IsRequired(true);
-        builder.Property(e => e.Note).IsRequired(true);
+        builder.Property(e => e.Note).IsRequired(false);
         builder.Property(e => e.BankName).IsRequired(true);
         builder.Property(e => e.AccountName).IsRequired(true);
         builder.Property(e => e.AccountNumber).IsRequired(true);
-        builder.Property(e => e.ImageUrl).IsRequired(true);
+        builder.Property(e => e.ImageUrl).IsRequired(false);
         builder.Property(e => e.Reason).IsRequired(false);
         builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");


### PR DESCRIPTION
Introduces PlannedDistance and ActualDistance fields to activity set DTOs, commands, and mapping profiles to support distance-based activities. Adds the ability to delete a session activity, with validation to prevent deletion if activity sets exist. Also updates withdrawal request configuration to make Note and ImageUrl fields optional.