### PR TITLE
#92 Add Quartz jobs for auto-cancel and auto-reject bookings

### DIFF
--- a/FitBridge_Application/Features/Bookings/AcceptBookingRequestCommand/AcceptBookingRequestCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/AcceptBookingRequestCommand/AcceptBookingRequestCommandHandler.cs
@@ -8,10 +8,11 @@ using FitBridge_Domain.Exceptions;
 using AutoMapper;
 using FitBridge_Domain.Entities.Gyms;
 using FitBridge_Application.Specifications.Bookings.GetFreelancePtBookingForValidate;
+using FitBridge_Application.Interfaces.Services;
 
 namespace FitBridge_Application.Features.Bookings.AcceptBookingRequestCommand;
 
-public class AcceptBookingRequestCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<AcceptBookingRequestCommand, Guid>
+public class AcceptBookingRequestCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapper, IScheduleJobServices _scheduleJobServices) : IRequestHandler<AcceptBookingRequestCommand, Guid>
 {
     public async Task<Guid> Handle(AcceptBookingRequestCommand request, CancellationToken cancellationToken)
     {
@@ -40,6 +41,7 @@ public class AcceptBookingRequestCommandHandler(IUnitOfWork _unitOfWork, IMapper
         customerPurchased.AvailableSessions--;
         _unitOfWork.Repository<CustomerPurchased>().Update(customerPurchased);
         _unitOfWork.Repository<BookingRequest>().Update(bookingRequest);
+        await _scheduleJobServices.ScheduleAutoCancelBookingJob(newBooking);
         await _unitOfWork.CommitAsync();
         return request.BookingRequestId;
     }

--- a/FitBridge_Application/Features/Bookings/StartBookingSession/StartBookingSessionCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/StartBookingSession/StartBookingSessionCommandHandler.cs
@@ -26,6 +26,7 @@ public class StartBookingSessionCommandHandler(IUnitOfWork _unitOfWork, ISchedul
         booking.UpdatedAt = DateTime.UtcNow;
         _unitOfWork.Repository<Booking>().Update(booking);
         await ScheduleFinishedBookingSession(booking);
+        await CancelAutoCancelBookingJob(booking);
         await _unitOfWork.CommitAsync();
         return booking.SessionStartTime.Value;
     }
@@ -38,5 +39,10 @@ public class StartBookingSessionCommandHandler(IUnitOfWork _unitOfWork, ISchedul
             BookingId = booking.Id,
             TriggerTime = booking.SessionStartTime.Value.AddMinutes(durationInMinutes)
         });
+    }
+
+    public async Task CancelAutoCancelBookingJob(Booking booking)
+    {
+        await _scheduleJobServices.CancelScheduleJob($"AutoCancelBooking_{booking.Id}", "AutoCancelBooking");
     }
 }

--- a/FitBridge_Application/FitBridge_Application.csproj
+++ b/FitBridge_Application/FitBridge_Application.csproj
@@ -23,6 +23,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Quartz" Version="3.15.0" />
+		<PackageReference Include="Quartz.Serialization.Json" Version="3.15.0" />
 		<PackageReference Include="StackExchange.Redis" Version="2.9.11" />
 		<PackageReference Include="Redis.OM" Version="1.0.1" />
 		<PackageReference Include="System.Formats.Asn1" Version="9.0.8" />

--- a/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
+++ b/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
@@ -1,5 +1,6 @@
 using System;
 using FitBridge_Application.Dtos.Jobs;
+using FitBridge_Domain.Entities.Trainings;
 
 namespace FitBridge_Application.Interfaces.Services;
 
@@ -9,4 +10,6 @@ public interface IScheduleJobServices
 
     Task<bool> ScheduleFinishedBookingSession(FinishedBookingSessionJobScheduleDto finishedBookingSessionJobScheduleDto);
     Task<bool> CancelScheduleJob(string jobName, string jobGroup);
+    Task<bool> ScheduleAutoCancelBookingJob(Booking booking);
+    Task<bool> ScheduleAutoRejectBookingRequestJob(BookingRequest bookingRequest);
 }

--- a/FitBridge_Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/FitBridge_Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -128,6 +128,16 @@ namespace FitBridge_Infrastructure.Extensions
                     .WithIdentity("EnableStartingCouponsTrigger")
                     .WithCronSchedule("0 0 0 * * ?") // Run daily at 00:00:00
                     .WithDescription("Enables starting coupons daily at midnight"));
+                q.UsePersistentStore(store =>
+                {
+                    store.UsePostgres(postgres =>
+                    {
+                        postgres.ConnectionString = configuration.GetConnectionString("FitBridgeDb");
+                        postgres.TablePrefix = "qrtz_";
+                    });
+                    store.UseNewtonsoftJsonSerializer();
+                    store.UseClustering();
+                });
             });
 
             services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);

--- a/FitBridge_Infrastructure/FitBridge_Infrastructure.csproj
+++ b/FitBridge_Infrastructure/FitBridge_Infrastructure.csproj
@@ -31,6 +31,7 @@
 		<PackageReference Include="Quartz" Version="3.15.0" />
 		<PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.15.0" />
 		<PackageReference Include="Quartz.Extensions.Hosting" Version="3.15.0" />
+		<PackageReference Include="Quartz.Serialization.Json" Version="3.15.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FitBridge_Infrastructure/Jobs/BookingRequests/RejectBookingRequestJob.cs
+++ b/FitBridge_Infrastructure/Jobs/BookingRequests/RejectBookingRequestJob.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.Extensions.Logging;
+using FitBridge_Application.Interfaces.Repositories;
+using Quartz;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Enums.Trainings;
+using FitBridge_Domain.Exceptions;
+
+namespace FitBridge_Infrastructure.Jobs.BookingRequests;
+
+public class RejectBookingRequestJob(ILogger<RejectBookingRequestJob> _logger, IUnitOfWork _unitOfWork) : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var bookingRequestId = Guid.Parse(context.JobDetail.JobDataMap.GetString("bookingRequestId")
+            ?? throw new NotFoundException($"{nameof(RejectBookingRequestJob)}_bookingRequestId"));
+        _logger.LogInformation("RejectBookingRequestJob started for BookingRequest: {BookingRequestId}", bookingRequestId);
+        var bookingRequest = await _unitOfWork.Repository<BookingRequest>().GetByIdAsync(bookingRequestId);
+        if (bookingRequest == null)
+        {
+            _logger.LogError("BookingRequest not found for BookingRequestId: {BookingRequestId}", bookingRequestId);
+            return;
+        }
+        if (bookingRequest.RequestStatus != BookingRequestStatus.Pending)
+        {
+            _logger.LogWarning("BookingRequest is not pending, current status: {BookingRequestStatus}", bookingRequest.RequestStatus);
+            return;
+        }
+        bookingRequest.RequestStatus = BookingRequestStatus.Rejected;
+        bookingRequest.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<BookingRequest>().Update(bookingRequest);
+        await _unitOfWork.CommitAsync();
+    }
+}

--- a/FitBridge_Infrastructure/Jobs/Bookings/CancelBookingJob.cs
+++ b/FitBridge_Infrastructure/Jobs/Bookings/CancelBookingJob.cs
@@ -1,0 +1,34 @@
+using System;
+using Quartz;
+using Microsoft.Extensions.Logging;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Enums.Trainings;
+
+namespace FitBridge_Infrastructure.Jobs.Bookings;
+
+public class CancelBookingJob(ILogger<CancelBookingJob> _logger, IUnitOfWork _unitOfWork) : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var bookingId = Guid.Parse(context.JobDetail.JobDataMap.GetString("bookingId")
+            ?? throw new NotFoundException($"{nameof(CancelBookingJob)}_bookingId"));
+        _logger.LogInformation("CancelBookingJob started for Booking: {BookingId}", bookingId);
+        var booking = await _unitOfWork.Repository<Booking>().GetByIdAsync(bookingId);
+        if (booking == null)
+        {
+            _logger.LogError("Booking not found for BookingId: {BookingId}", bookingId);
+            return;
+        }
+        if (booking.SessionStatus != SessionStatus.Booked)
+        {
+            _logger.LogWarning("Booking is not booked, current status: {SessionStatus}", booking.SessionStatus);
+            return;
+        }
+        booking.SessionStatus = SessionStatus.Cancelled;
+        booking.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<Booking>().Update(booking);
+        await _unitOfWork.CommitAsync();
+    }
+}

--- a/FitBridge_Infrastructure/Services/PayOSService.cs
+++ b/FitBridge_Infrastructure/Services/PayOSService.cs
@@ -21,6 +21,7 @@ using FitBridge_Domain.Enums.Payments;
 using FitBridge_Application.Commons.Constants;
 using Quartz;
 using FitBridge_Infrastructure.Jobs;
+using JsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
 
 namespace FitBridge_Infrastructure.Services;
 


### PR DESCRIPTION
Introduces Quartz jobs to automatically cancel bookings and reject booking requests if not processed in time. Updates command handlers to schedule these jobs, extends IScheduleJobServices with new scheduling methods, and configures Quartz persistent store with JSON serialization. Also updates project dependencies to include Quartz.Serialization.Json.