### PR TITLE
#92 Update PT info in CustomerPurchasedResponseDto

### DIFF
--- a/FitBridge_Application/Dtos/CustomerPurchaseds/CustomerPurchasedResponseDto.cs
+++ b/FitBridge_Application/Dtos/CustomerPurchaseds/CustomerPurchasedResponseDto.cs
@@ -15,8 +15,8 @@ public class CustomerPurchasedResponseDto
     public DateOnly ExpirationDate { get; set; }
     public bool CanAssignPT { get; set; }
     public decimal PTAssignmentPrice { get; set; }
-
-    // PT Information (if assigned)
-    public ICollection<GymCoursePtDto>? PtList { get; set; }
     public Guid? GymCourseId { get; set; }
+    public Guid? PtId { get; set; }
+    public string? PtName { get; set; }
+    public string? PtImageUrl { get; set; }
 }

--- a/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/CustomerPurchasedMappingProfile.cs
@@ -34,7 +34,9 @@ public class CustomerPurchasedMappingProfile : Profile
             .ForMember(dest => dest.ExpirationDate, opt => opt.MapFrom(src => src.ExpirationDate))
             .ForMember(dest => dest.CanAssignPT, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPtId == null))
             .ForMember(dest => dest.PTAssignmentPrice, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.PtPrice))
-                .ForMember(dest => dest.PtList, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourse.GymCoursePTs))
+            .ForMember(dest => dest.PtId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPtId))
+            .ForMember(dest => dest.PtName, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPt.FullName))
+            .ForMember(dest => dest.PtImageUrl, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymPt.AvatarUrl))
             .ForMember(dest => dest.GymCourseId, opt => opt.MapFrom(src => src.OrderItems.OrderByDescending(x => x.CreatedAt).First().GymCourseId))
             ;
 


### PR DESCRIPTION
Replaced PtList with PtId, PtName, and PtImageUrl in CustomerPurchasedResponseDto to provide direct PT assignment details. Updated mapping profile to map new PT fields from the latest order item.