### PR TITLE
#92 Add profit distribution scheduling and handling

### DIFF
--- a/FitBridge_API/Controllers/JobsController.cs
+++ b/FitBridge_API/Controllers/JobsController.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using MediatR;
+using FitBridge_Application.Features.Jobs.DistributeProfit;
+using FitBridge_API.Helpers.RequestHelpers;
+
+namespace FitBridge_API.Controllers;
+
+public class JobsController(IMediator mediator) : _BaseApiController
+{
+    /// <summary>
+    /// Schedule a job to distribute profit
+    /// </summary>
+    /// <param name="command"></param>
+    /// <returns></returns>
+    [HttpPost("schedule-distribute-profit")]
+    public async Task<IActionResult> ScheduleDistributeProfit([FromBody] DistributeProfitCommand command)
+    {
+        var response = await mediator.Send(command);
+        return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Profit distributed successfully", response));
+    }
+}

--- a/FitBridge_Application/Commons/Constants/ProjectConstant.cs
+++ b/FitBridge_Application/Commons/Constants/ProjectConstant.cs
@@ -3,6 +3,7 @@ namespace FitBridge_Application.Commons.Constants;
 public static class ProjectConstant
 {
     public const string defaultAvatar = "https://img.icons8.com/?size=100&id=tZuAOUGm9AuS&format=png&color=000000";
+    public const int ProfitDistributionDays = 30;
 
     public static class UserRoles
     {

--- a/FitBridge_Application/Features/Bookings/AcceptBookingRequestCommand/AcceptBookingRequestCommandHandler.cs
+++ b/FitBridge_Application/Features/Bookings/AcceptBookingRequestCommand/AcceptBookingRequestCommandHandler.cs
@@ -42,6 +42,7 @@ public class AcceptBookingRequestCommandHandler(IUnitOfWork _unitOfWork, IMapper
         _unitOfWork.Repository<CustomerPurchased>().Update(customerPurchased);
         _unitOfWork.Repository<BookingRequest>().Update(bookingRequest);
         await _scheduleJobServices.ScheduleAutoCancelBookingJob(newBooking);
+        await _scheduleJobServices.CancelScheduleJob($"AutoRejectBookingRequest_{bookingRequest.Id}", "AutoRejectBookingRequest");
         await _unitOfWork.CommitAsync();
         return request.BookingRequestId;
     }

--- a/FitBridge_Application/Features/Jobs/DistributeProfit/DistributeProfitCommand.cs
+++ b/FitBridge_Application/Features/Jobs/DistributeProfit/DistributeProfitCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.Jobs.DistributeProfit;
+
+public class DistributeProfitCommand : IRequest<bool>
+{
+    public Guid OrderItemId { get; set; }
+    public DateOnly ProfitDistributionDate { get; set; }
+}

--- a/FitBridge_Application/Features/Jobs/DistributeProfit/DistributeProfitCommandHandler.cs
+++ b/FitBridge_Application/Features/Jobs/DistributeProfit/DistributeProfitCommandHandler.cs
@@ -1,0 +1,19 @@
+using System;
+using FitBridge_Application.Dtos.Jobs;
+using FitBridge_Application.Interfaces.Services;
+using MediatR;
+
+namespace FitBridge_Application.Features.Jobs.DistributeProfit;
+
+public class DistributeProfitCommandHandler(IScheduleJobServices _scheduleJobServices) : IRequestHandler<DistributeProfitCommand, bool>
+{
+    public async Task<bool> Handle(DistributeProfitCommand request, CancellationToken cancellationToken)
+    {
+        return await _scheduleJobServices.ScheduleProfitDistributionJob(new ProfitJobScheduleDto
+        {
+            OrderItemId = request.OrderItemId,
+            ProfitDistributionDate = request.ProfitDistributionDate
+        });
+    }
+
+}

--- a/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
+++ b/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
@@ -1,6 +1,7 @@
 using System;
 using FitBridge_Application.Dtos.Jobs;
 using FitBridge_Domain.Entities.Trainings;
+using Quartz;
 
 namespace FitBridge_Application.Interfaces.Services;
 
@@ -12,4 +13,6 @@ public interface IScheduleJobServices
     Task<bool> CancelScheduleJob(string jobName, string jobGroup);
     Task<bool> ScheduleAutoCancelBookingJob(Booking booking);
     Task<bool> ScheduleAutoRejectBookingRequestJob(BookingRequest bookingRequest);
+    Task<TriggerState> GetJobStatus(string jobName, string jobGroup);
+    Task<bool> RescheduleJob(string jobName, string jobGroup, DateTime triggerTime);
 }

--- a/FitBridge_Application/Interfaces/Services/ITransactionService.cs
+++ b/FitBridge_Application/Interfaces/Services/ITransactionService.cs
@@ -11,4 +11,5 @@ public interface ITransactionService
     Task<bool> PurchaseFreelancePTPackage(long orderCode);
     Task<bool> PurchaseGymCourse(long orderCode);
     Task<bool> ExtendFreelancePTPackage(long orderCode);
+    Task<bool> DistributePendingProfit(Guid CustomerPurchasedId);
 }

--- a/FitBridge_Application/Services/TransactionsService.cs
+++ b/FitBridge_Application/Services/TransactionsService.cs
@@ -15,6 +15,7 @@ using FitBridge_Application.Specifications.Orders;
 using Quartz;
 using FitBridge_Application.Dtos.Jobs;
 using FitBridge_Application.Dtos.Payments;
+using FitBridge_Domain.Enums.Trainings;
 
 namespace FitBridge_Application.Services;
 
@@ -54,6 +55,8 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
         }
         customerPurchasedToExtend.AvailableSessions += orderItemToExtend.Quantity * numOfSession;
         customerPurchasedToExtend.ExpirationDate = customerPurchasedToExtend.ExpirationDate.AddDays(orderItemToExtend.GymCourse.Duration * orderItemToExtend.Quantity);
+        var profitDistributionDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(ProjectConstant.ProfitDistributionDays); // Profit distribute planned date is the day after the expiration date
+        orderItemToExtend.ProfitDistributePlannedDate = profitDistributionDate;
         transactionToExtend.Order.Status = OrderStatus.Finished;
         var walletToUpdate = await _unitOfWork.Repository<Wallet>().GetByIdAsync(orderItemToExtend.GymCourse.GymOwnerId);
         if (walletToUpdate == null)
@@ -71,7 +74,7 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
         await _scheduleJobServices.ScheduleProfitDistributionJob(new ProfitJobScheduleDto
         {
             OrderItemId = orderItemToExtend.Id,
-            ProfitDistributionDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(30)
+            ProfitDistributionDate = profitDistributionDate
         });
         return true;
     }
@@ -129,6 +132,7 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
         {
             Amount = profit,
             OrderId = orderItem.OrderId,
+            OrderItemId = orderItemId,
             TransactionType = TransactionType.DistributeProfit,
             Status = TransactionStatus.Success,
             Description = $"Profit distribution for completed course - OrderItem: {orderItemId}",
@@ -153,7 +157,9 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
         _logger.LogInformation($"Wallet {wallet.Id} updated with available balance {wallet.AvailableBalance} plus {profit} and pending balance {wallet.PendingBalance} minus {profit}");
         wallet.AvailableBalance += profit;
         wallet.PendingBalance -= profit;
-
+        orderItem.ProfitDistributeActualDate = DateOnly.FromDateTime(DateTime.UtcNow); // Profit distribute actual date is the current date
+        orderItem.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<OrderItem>().Update(orderItem);
         _unitOfWork.Repository<Wallet>().Update(wallet);
         await _unitOfWork.CommitAsync();
         return true;
@@ -199,7 +205,8 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
 
             numOfSession = orderItem.FreelancePTPackage.NumOfSessions;
             expirationDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(orderItem.FreelancePTPackage.DurationInDays * orderItem.Quantity);
-            profitDistributionDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(orderItem.FreelancePTPackage.DurationInDays * orderItem.Quantity);
+            profitDistributionDate = expirationDate.AddDays(1); // Profit distribute planned date is the day after the expiration date
+            orderItem.ProfitDistributePlannedDate = profitDistributionDate;
 
             orderItem.CustomerPurchased = new CustomerPurchased
             {
@@ -275,7 +282,8 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
             {
                 var expirationDate = DateOnly.FromDateTime(DateTime.UtcNow);
                 var numOfSession = 0;
-                var profitDistributionDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(30);
+                var profitDistributionDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(ProjectConstant.ProfitDistributionDays);
+                orderItem.ProfitDistributePlannedDate = profitDistributionDate;
                 if (orderItem.GymCourseId != null && orderItem.GymPtId != null)
                 {
                     var gymCoursePT = await _unitOfWork.Repository<GymCoursePT>().GetBySpecificationAsync(new GetGymCoursePtByGymCourseIdAndPtIdSpec(orderItem.GymCourseId.Value, orderItem.GymPtId.Value));
@@ -334,6 +342,11 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
         var numOfSession = orderItemToExtend.FreelancePTPackage.NumOfSessions;
         customerPurchasedToExtend.AvailableSessions += orderItemToExtend.Quantity * numOfSession;
         customerPurchasedToExtend.ExpirationDate = customerPurchasedToExtend.ExpirationDate.AddDays(orderItemToExtend.FreelancePTPackage.DurationInDays * orderItemToExtend.Quantity);
+
+        var profitDistributePlannedDate = customerPurchasedToExtend.ExpirationDate.AddDays(1); // Profit distribute planned date is the day after the expiration date
+
+        orderItemToExtend.ProfitDistributePlannedDate = profitDistributePlannedDate;
+
         transactionToExtend.Order.Status = OrderStatus.Finished;
         var walletToUpdate = await _unitOfWork.Repository<Wallet>().GetByIdAsync(orderItemToExtend.FreelancePTPackage.PtId);
         if (walletToUpdate == null)
@@ -346,12 +359,63 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
 
         _unitOfWork.Repository<Wallet>().Update(walletToUpdate);
         await _unitOfWork.CommitAsync();
-
         await _scheduleJobServices.ScheduleProfitDistributionJob(new ProfitJobScheduleDto
         {
             OrderItemId = orderItemToExtend.Id,
-            ProfitDistributionDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(30)
+            ProfitDistributionDate = profitDistributePlannedDate
         });
+        return true;
+    }
+
+    public async Task<bool> DistributePendingProfit(Guid CustomerPurchasedId)
+    {
+        var customerPurchased = await _unitOfWork.Repository<CustomerPurchased>().GetByIdAsync(CustomerPurchasedId, false, new List<string> { "OrderItems", "OrderItems.Order", "OrderItems.Order.Coupon", "Bookings", "OrderItems.FreelancePTPackage" });
+        if (customerPurchased == null)
+        {
+            throw new NotFoundException("Customer purchased not found");
+        }
+        var finishedBookings = customerPurchased.Bookings.Count(b => b.SessionStatus == SessionStatus.Finished);
+        var orderItemsList = customerPurchased.OrderItems.OrderBy(o => o.CreatedAt).ToList();
+        // Track how many sessions have been "allocated" to previous order items
+        var allocatedSessionsForDistribute = 0;
+        foreach (var orderItem in orderItemsList)
+        {
+            var numOfSessionForDistribute = (int)Math.Ceiling(orderItem.Quantity * orderItem.FreelancePTPackage.NumOfSessions / 2.0); //Customer have to finished more than half of the sessions that they have purchased in this order item to distribute profit
+            allocatedSessionsForDistribute += numOfSessionForDistribute;
+
+            if (finishedBookings >= allocatedSessionsForDistribute
+            && orderItem.ProfitDistributeActualDate == null)
+            {
+                var distributeDate = DateOnly.FromDateTime(DateTime.UtcNow.Date).AddDays(1);
+                var jobStatus = await _scheduleJobServices.GetJobStatus($"ProfitDistribution_{orderItem.Id}", "ProfitDistribution");
+                _logger.LogInformation($"Profit distribution job for order item {orderItem.Id} state is {jobStatus}");
+                if (jobStatus == TriggerState.Paused)
+                {
+                    _logger.LogInformation($"Profit distribution job for order item {orderItem.Id} is already paused");
+                    continue;
+                }
+                if (jobStatus == TriggerState.Normal)
+                {
+                    _logger.LogInformation($"Profit distribution job state is {jobStatus}");
+                    // var rescheduleJob = await _scheduleJobServices.RescheduleJob($"ProfitDistribution_{orderItem.Id}", "ProfitDistribution", distributeDate.ToDateTime(TimeOnly.MinValue)); //Reschedule the job if it is not paused
+                    var rescheduleJob = await _scheduleJobServices.RescheduleJob($"ProfitDistribution_{orderItem.Id}", "ProfitDistribution", DateTime.UtcNow);
+                    if (!rescheduleJob)
+                    {
+                        _logger.LogError($"Failed to reschedule profit distribution job for order item {orderItem.Id}");
+                        continue;
+                    }
+                    orderItem.ProfitDistributePlannedDate = distributeDate;
+                    orderItem.UpdatedAt = DateTime.UtcNow;
+                    _unitOfWork.Repository<OrderItem>().Update(orderItem);
+                    _logger.LogInformation($"Successfully rescheduled profit distribution job for order item {orderItem.Id} at {distributeDate}");
+
+                }
+            }
+        }
+        _logger.LogInformation("Number of finished booking:" + finishedBookings);
+        _logger.LogInformation("Number of allocated session:" + allocatedSessionsForDistribute);
+        await _unitOfWork.CommitAsync();
+
         return true;
     }
 }

--- a/FitBridge_Domain/Entities/Orders/OrderItem.cs
+++ b/FitBridge_Domain/Entities/Orders/OrderItem.cs
@@ -24,11 +24,14 @@ public class OrderItem : BaseEntity
     public Guid? GymCourseId { get; set; }
     public Guid? ServiceInformationId { get; set; }
     public Guid? FreelancePTPackageId { get; set; }
+    public DateOnly? ProfitDistributePlannedDate { get; set; }
+    public DateOnly? ProfitDistributeActualDate { get; set; }
     public ServiceInformation? ServiceInformation { get; set; }
     public ProductDetail? ProductDetail { get; set; }
     public GymCourse? GymCourse { get; set; }
     public CustomerPurchased? CustomerPurchased { get; set; }
     public ApplicationUser? GymPt { get; set; }
     public FreelancePTPackage? FreelancePTPackage { get; set; }
+    public ICollection<Transaction> Transactions { get; set; } = new List<Transaction>();
     public ICollection<ReportCases> ReportCases { get; set; } = new List<ReportCases>();
 }

--- a/FitBridge_Domain/Entities/Orders/Transaction.cs
+++ b/FitBridge_Domain/Entities/Orders/Transaction.cs
@@ -5,9 +5,8 @@ namespace FitBridge_Domain.Entities.Orders;
 public class Transaction : BaseEntity
 {
     public TransactionStatus Status { get; set; }
-
+    public Guid? OrderItemId { get; set; }
     public decimal Amount { get; set; }
-
     public long OrderCode { get; set; }
 
     public string Description { get; set; }
@@ -20,9 +19,8 @@ public class Transaction : BaseEntity
     public decimal? ProfitAmount { get; set; }
 
     public PaymentMethod PaymentMethod { get; set; }
-
+    public OrderItem? OrderItem { get; set; }
     public WithdrawalRequest? WithdrawalRequest { get; set; }
-
     public Order? Order { get; set; }
 
     public TransactionType TransactionType { get; set; }

--- a/FitBridge_Domain/Enums/Orders/TransactionType.cs
+++ b/FitBridge_Domain/Enums/Orders/TransactionType.cs
@@ -13,6 +13,6 @@
         AssignPt,
         ExtendCourse,
         ExtendFreelancePTPackage,
-        DistributeProfit
+        DistributeProfit,
     }
 }

--- a/FitBridge_Infrastructure/Configurations/OrderItemConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/OrderItemConfiguration.cs
@@ -17,7 +17,8 @@ public class OrderItemConfiguration : IEntityTypeConfiguration<OrderItem>
         builder.Property(e => e.Price).IsRequired(true);
         builder.Property(e => e.OrderId).IsRequired(true);
         builder.Property(e => e.ProductDetailId).IsRequired(false);
-
+        builder.Property(e => e.ProfitDistributePlannedDate).IsRequired(false);
+        builder.Property(e => e.ProfitDistributeActualDate).IsRequired(false);
         builder.HasOne(e => e.Order).WithMany(e => e.OrderItems).HasForeignKey(e => e.OrderId);
         builder.HasOne(e => e.ServiceInformation).WithMany(e => e.OrderItems).HasForeignKey(e => e.ServiceInformationId).OnDelete(DeleteBehavior.Restrict);
         builder.HasOne(e => e.ProductDetail).WithMany(e => e.OrderItems).HasForeignKey(e => e.ProductDetailId).OnDelete(DeleteBehavior.Restrict);

--- a/FitBridge_Infrastructure/Configurations/TransactionConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/TransactionConfiguration.cs
@@ -20,11 +20,11 @@ public class TransactionConfiguration : IEntityTypeConfiguration<Transaction>
         builder.Property(e => e.WithdrawalRequestId).IsRequired(false);
         builder.Property(e => e.OrderId).IsRequired(false);
         builder.Property(e => e.ProfitAmount).IsRequired(false);
-
+        builder.Property(e => e.OrderItemId).IsRequired(false);
         builder.HasOne(e => e.PaymentMethod).WithMany(e => e.Transactions).HasForeignKey(e => e.PaymentMethodId);
         builder.HasOne(e => e.WithdrawalRequest).WithMany(e => e.Transactions).HasForeignKey(e => e.WithdrawalRequestId);
         builder.HasOne(e => e.Order).WithMany(e => e.Transactions).HasForeignKey(e => e.OrderId);
-
+        builder.HasOne(e => e.OrderItem).WithMany(e => e.Transactions).HasForeignKey(e => e.OrderItemId);
         builder.Property(e => e.TransactionType).HasConversion(convertToProviderExpression: s => s.ToString(), convertFromProviderExpression: s => Enum.Parse<TransactionType>(s));
     }
 }

--- a/FitBridge_Infrastructure/Jobs/Bookings/FinishedBookingSessionJob.cs
+++ b/FitBridge_Infrastructure/Jobs/Bookings/FinishedBookingSessionJob.cs
@@ -5,10 +5,11 @@ using FitBridge_Domain.Enums.Trainings;
 using FitBridge_Domain.Exceptions;
 using Microsoft.Extensions.Logging;
 using Quartz;
+using FitBridge_Application.Interfaces.Services;
 
 namespace FitBridge_Infrastructure.Jobs.Bookings;
 
-public class FinishedBookingSessionJob(ILogger<FinishedBookingSessionJob> _logger, IUnitOfWork _unitOfWork) : IJob
+public class FinishedBookingSessionJob(ILogger<FinishedBookingSessionJob> _logger, IUnitOfWork _unitOfWork, ITransactionService _transactionService) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -25,6 +26,7 @@ public class FinishedBookingSessionJob(ILogger<FinishedBookingSessionJob> _logge
         booking.SessionEndTime = DateTime.UtcNow;
         booking.UpdatedAt = DateTime.UtcNow;
         _unitOfWork.Repository<Booking>().Update(booking);
+        var distributePendingProfitResult = await _transactionService.DistributePendingProfit(booking.CustomerPurchasedId);
         await _unitOfWork.CommitAsync();
     }
 }


### PR DESCRIPTION
Introduces profit distribution logic, including new commands, handlers, and controller endpoints for scheduling profit distribution jobs. Updates domain models and configurations to support planned and actual profit distribution dates, links transactions to order items, and adds job status/rescheduling methods. Implements pending profit distribution after booking session completion and refines session/job handling in booking workflows.