### PR TITLE
#203 Add current body metrics to user goals

### DIFF
--- a/FitBridge_API/Controllers/UserGoalsController.cs
+++ b/FitBridge_API/Controllers/UserGoalsController.cs
@@ -21,9 +21,10 @@ public class UserGoalsController(IMediator _mediator) : _BaseApiController
         return Ok(new BaseResponse<UserGoalsDto>(StatusCodes.Status200OK.ToString(), "User goal created successfully", result));
     }
 
-    [HttpPut]
-    public async Task<IActionResult> UpdateUserGoal([FromBody] UpdateUserGoalCommand command)
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateUserGoal([FromBody] UpdateUserGoalCommand command, [FromRoute] Guid id)
     {
+        command.Id = id;
         var result = await _mediator.Send(command);
         return Ok(new BaseResponse<UserGoalsDto>(StatusCodes.Status200OK.ToString(), "User goal updated successfully", result));
     }

--- a/FitBridge_Application/Dtos/UserGoals/UserGoalsDto.cs
+++ b/FitBridge_Application/Dtos/UserGoals/UserGoalsDto.cs
@@ -26,6 +26,17 @@ public class UserGoalsDto
     public double? StartHeight { get; set; }
     public double? StartWeight { get; set; }
 
+    public double? CurrentBiceps { get; set; }
+    public double? CurrentForeArm { get; set; }
+    public double? CurrentThigh { get; set; }
+    public double? CurrentCalf { get; set; }
+    public double? CurrentChest { get; set; }
+    public double? CurrentWaist { get; set; }
+    public double? CurrentHip { get; set; }
+    public double? CurrentShoulder { get; set; }
+    public double? CurrentHeight { get; set; }
+    public double? CurrentWeight { get; set; }
+
     public string? ImageUrl { get; set; }
     public string? FinalImageUrl { get; set; }
 }

--- a/FitBridge_Application/Features/UserGoals/CreateUserGoalCommand.cs
+++ b/FitBridge_Application/Features/UserGoals/CreateUserGoalCommand.cs
@@ -31,5 +31,4 @@ public class CreateUserGoalCommand : IRequest<UserGoalsDto>
     public double? StartWeight { get; set; }
 
     public string? ImageUrl { get; set; }
-    public string? FinalImageUrl { get; set; }
 }

--- a/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommand.cs
+++ b/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using FitBridge_Application.Dtos.UserGoals;
 using MediatR;
+using System.Text.Json.Serialization;
 
 namespace FitBridge_Application.Features.UserGoals.UpdateUserGoals;
 
 public class UpdateUserGoalCommand : IRequest<UserGoalsDto>
 {
+    [JsonIgnore]
     public Guid Id { get; set; }
     public double? TargetBiceps { get; set; }
     public double? TargetForeArm { get; set; }
@@ -28,6 +30,17 @@ public class UpdateUserGoalCommand : IRequest<UserGoalsDto>
     public double? StartShoulder { get; set; }
     public double? StartHeight { get; set; }
     public double? StartWeight { get; set; }
+
+    public double? CurrentBiceps { get; set; }
+    public double? CurrentForeArm { get; set; }
+    public double? CurrentThigh { get; set; }
+    public double? CurrentCalf { get; set; }
+    public double? CurrentChest { get; set; }
+    public double? CurrentWaist { get; set; }
+    public double? CurrentHip { get; set; }
+    public double? CurrentShoulder { get; set; }
+    public double? CurrentHeight { get; set; }
+    public double? CurrentWeight { get; set; }
 
     public string? ImageUrl { get; set; }
     public string? FinalImageUrl { get; set; }

--- a/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommandHandler.cs
+++ b/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommandHandler.cs
@@ -27,6 +27,7 @@ public class UpdateUserGoalCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
         userGoal.TargetShoulder = request.TargetShoulder ?? userGoal.TargetShoulder;
         userGoal.TargetHeight = request.TargetHeight ?? userGoal.TargetHeight;
         userGoal.TargetWeight = request.TargetWeight ?? userGoal.TargetWeight;
+
         userGoal.StartBiceps = request.StartBiceps ?? userGoal.StartBiceps;
         userGoal.StartForeArm = request.StartForeArm ?? userGoal.StartForeArm;
         userGoal.StartThigh = request.StartThigh ?? userGoal.StartThigh;
@@ -37,8 +38,20 @@ public class UpdateUserGoalCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
         userGoal.StartShoulder = request.StartShoulder ?? userGoal.StartShoulder;
         userGoal.StartHeight = request.StartHeight ?? userGoal.StartHeight;
         userGoal.StartWeight = request.StartWeight ?? userGoal.StartWeight;
+
+        userGoal.FinalBiceps = request.CurrentBiceps ?? userGoal.FinalBiceps;
+        userGoal.FinalForeArm = request.CurrentForeArm ?? userGoal.FinalForeArm;
+        userGoal.FinalThigh = request.CurrentThigh ?? userGoal.FinalThigh;
+        userGoal.FinalCalf = request.CurrentCalf ?? userGoal.FinalCalf;
+        userGoal.FinalChest = request.CurrentChest ?? userGoal.FinalChest;
+        userGoal.FinalWaist = request.CurrentWaist ?? userGoal.FinalWaist;
+        userGoal.FinalHip = request.CurrentHip ?? userGoal.FinalHip;
+        userGoal.FinalShoulder = request.CurrentShoulder ?? userGoal.FinalShoulder;
+        userGoal.FinalHeight = request.CurrentHeight ?? userGoal.FinalHeight;
+        userGoal.FinalWeight = request.CurrentWeight ?? userGoal.FinalWeight;
         userGoal.ImageUrl = request.ImageUrl ?? userGoal.ImageUrl;
         userGoal.FinalImageUrl = request.FinalImageUrl ?? userGoal.FinalImageUrl;
+        
         _unitOfWork.Repository<UserGoal>().Update(userGoal);
         await _unitOfWork.CommitAsync();
         return _mapper.Map<UserGoal, UserGoalsDto>(userGoal);

--- a/FitBridge_Application/MappingProfiles/UserGoalsMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/UserGoalsMappingProfile.cs
@@ -10,7 +10,18 @@ public class UserGoalsMappingProfile : Profile
 {
     public UserGoalsMappingProfile()
     {
-        CreateMap<UserGoal, UserGoalsDto>();
+        CreateMap<UserGoal, UserGoalsDto>()
+        .ForMember(dest => dest.CurrentBiceps, opt => opt.MapFrom(src => src.FinalBiceps))
+        .ForMember(dest => dest.CurrentForeArm, opt => opt.MapFrom(src => src.FinalForeArm))
+        .ForMember(dest => dest.CurrentThigh, opt => opt.MapFrom(src => src.FinalThigh))
+        .ForMember(dest => dest.CurrentCalf, opt => opt.MapFrom(src => src.FinalCalf))
+        .ForMember(dest => dest.CurrentChest, opt => opt.MapFrom(src => src.FinalChest))
+        .ForMember(dest => dest.CurrentWaist, opt => opt.MapFrom(src => src.FinalWaist))
+        .ForMember(dest => dest.CurrentHip, opt => opt.MapFrom(src => src.FinalHip))
+        .ForMember(dest => dest.CurrentShoulder, opt => opt.MapFrom(src => src.FinalShoulder))
+        .ForMember(dest => dest.CurrentHeight, opt => opt.MapFrom(src => src.FinalHeight))
+        .ForMember(dest => dest.CurrentWeight, opt => opt.MapFrom(src => src.FinalWeight));
+        
         CreateMap<CreateUserGoalCommand, UserGoal>();
     }
 }

--- a/FitBridge_Domain/Entities/Trainings/UserGoal.cs
+++ b/FitBridge_Domain/Entities/Trainings/UserGoal.cs
@@ -37,6 +37,8 @@ public class UserGoal : BaseEntity
     public double? FinalWaist { get; set; }
     public double? FinalHip { get; set; }
     public double? FinalShoulder { get; set; }
+    public double? FinalHeight { get; set; }
+    public double? FinalWeight { get; set; }
 
     public string? ImageUrl { get; set; }
     public string? FinalImageUrl { get; set; }

--- a/FitBridge_Infrastructure/Configurations/UserGoalConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/UserGoalConfiguration.cs
@@ -39,7 +39,8 @@ public class UserGoalConfiguration : IEntityTypeConfiguration<UserGoal>
         builder.Property(e => e.FinalWaist).IsRequired(false);
         builder.Property(e => e.FinalHip).IsRequired(false);
         builder.Property(e => e.FinalShoulder).IsRequired(false);
-
+        builder.Property(e => e.FinalHeight).IsRequired(false);
+        builder.Property(e => e.FinalWeight).IsRequired(false);
         builder.Property(e => e.ImageUrl).IsRequired(false);
         builder.Property(e => e.CustomerPurchasedId).IsRequired(true);
 

--- a/FitBridge_Infrastructure/Services/Uploads/UploadService.cs
+++ b/FitBridge_Infrastructure/Services/Uploads/UploadService.cs
@@ -2,6 +2,7 @@ using System;
 using Appwrite;
 using Appwrite.Models;
 using Appwrite.Services;
+using FitBridge_Application.Commons.Constants;
 using FitBridge_Application.Configurations;
 using FitBridge_Application.Interfaces.Services;
 using FitBridge_Domain.Exceptions;
@@ -14,8 +15,15 @@ public class UploadService(IOptions<AppWriteSettings> _appWriteSettings, Storage
 {
     public async Task<string> UploadFileAsync(IFormFile file)
     {
-        if (file == null || file.Length == 0)
-            throw new ArgumentException("No file uploaded.");
+
+        if (file == null || file.Length == 0) {
+            throw new BusinessException("No file uploaded.");
+        }
+        
+        if (file.Length > ProjectConstant.MaximumAvatarSize * 1024 * 1024)
+        {
+            throw new BusinessException($"File size is too large, maximum size is {ProjectConstant.MaximumAvatarSize}MB");
+        }
 
         var allowedExtensions = new[] { ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"};
         var fileExtension = Path.GetExtension(file.FileName).ToLower();


### PR DESCRIPTION
Introduces fields for current body measurements (e.g., biceps, weight, height) to UserGoalsDto and UpdateUserGoalCommand, maps them to final values in the domain model, and updates the handler logic. Also adds FinalHeight and FinalWeight to the UserGoal entity and configuration. UploadService now enforces a maximum avatar file size and returns more specific errors.