### PR TITLE
#203 Refactor user goal endpoints to use CustomerPurchasedId

### DIFF
--- a/FitBridge_API/Controllers/IdentitiesController.cs
+++ b/FitBridge_API/Controllers/IdentitiesController.cs
@@ -51,7 +51,7 @@ public class IdentitiesController(IMediator _mediator, IApplicationUserService _
         var user = await _applicationUserService.GetUserByEmailAsync(email, false);
         if (user == null)
         {
-            return BadRequest(new BaseResponse<string>(StatusCodes.Status400BadRequest.ToString(), "Invalid email address", user.Id.ToString()));
+            return BadRequest(new BaseResponse<string>(StatusCodes.Status400BadRequest.ToString(), "Invalid email address", null));
         }
 
         var result = await _applicationUserService.ConfirmEmailAsync(user, token);

--- a/FitBridge_API/Controllers/UserGoalsController.cs
+++ b/FitBridge_API/Controllers/UserGoalsController.cs
@@ -21,17 +21,24 @@ public class UserGoalsController(IMediator _mediator) : _BaseApiController
         return Ok(new BaseResponse<UserGoalsDto>(StatusCodes.Status200OK.ToString(), "User goal created successfully", result));
     }
 
-    [HttpPut("{id}")]
-    public async Task<IActionResult> UpdateUserGoal([FromBody] UpdateUserGoalCommand command, [FromRoute] Guid id)
+/// <summary>
+/// Update user goal
+/// </summary>
+/// <param name="command"></param>
+/// <param name="customerPurchasedId">Customer purchased id</param>
+/// <returns></returns>
+    [HttpPut("{customerPurchasedId}")]
+    public async Task<IActionResult> UpdateUserGoal([FromBody] UpdateUserGoalCommand command, [FromRoute] Guid customerPurchasedId)
     {
-        command.Id = id;
+        command.CustomerPurchasedId = customerPurchasedId;
         var result = await _mediator.Send(command);
         return Ok(new BaseResponse<UserGoalsDto>(StatusCodes.Status200OK.ToString(), "User goal updated successfully", result));
     }
-    [HttpGet("{id}")]
-    public async Task<IActionResult> GetUserGoalById([FromRoute] Guid id)
+
+    [HttpGet("{customerPurchasedId}")]
+    public async Task<IActionResult> GetUserGoalById([FromRoute] Guid customerPurchasedId)
     {
-        var result = await _mediator.Send(new GetUserGoalByIdQuery { Id = id });
+        var result = await _mediator.Send(new GetUserGoalByIdQuery { CustomerPurchasedId = customerPurchasedId });
         return Ok(new BaseResponse<UserGoalsDto>(StatusCodes.Status200OK.ToString(), "User goal retrieved successfully", result));
     }
 

--- a/FitBridge_Application/Features/UserGoals/GetUserGoalById/GetUserGoalByIdQuery.cs
+++ b/FitBridge_Application/Features/UserGoals/GetUserGoalById/GetUserGoalByIdQuery.cs
@@ -7,5 +7,5 @@ namespace FitBridge_Application.Features.UserGoals.GetUserGoalById;
 
 public class GetUserGoalByIdQuery : IRequest<UserGoalsDto>
 {
-    public Guid Id { get; set; }
+    public Guid CustomerPurchasedId { get; set; }
 }

--- a/FitBridge_Application/Features/UserGoals/GetUserGoalById/GetUserGoalByIdQueryHandler.cs
+++ b/FitBridge_Application/Features/UserGoals/GetUserGoalById/GetUserGoalByIdQueryHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using AutoMapper;
 using FitBridge_Domain.Entities.Trainings;
 using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Entities.Gyms;
 
 namespace FitBridge_Application.Features.UserGoals.GetUserGoalById;
 
@@ -12,7 +13,12 @@ public class GetUserGoalByIdQueryHandler(IUnitOfWork _unitOfWork, IMapper _mappe
 {
     public async Task<UserGoalsDto> Handle(GetUserGoalByIdQuery request, CancellationToken cancellationToken)
     {
-        var userGoal = await _unitOfWork.Repository<UserGoal>().GetByIdAsync(request.Id);
+        var customerPurchased = await _unitOfWork.Repository<CustomerPurchased>().GetByIdAsync(request.CustomerPurchasedId, false, new List<string> { "UserGoal" });
+        if (customerPurchased == null)
+        {
+            throw new NotFoundException("Customer purchased not found");
+        }
+        var userGoal = customerPurchased.UserGoal;
         if (userGoal == null)
         {
             throw new NotFoundException("User goal not found");

--- a/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommand.cs
+++ b/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommand.cs
@@ -8,7 +8,7 @@ namespace FitBridge_Application.Features.UserGoals.UpdateUserGoals;
 public class UpdateUserGoalCommand : IRequest<UserGoalsDto>
 {
     [JsonIgnore]
-    public Guid Id { get; set; }
+    public Guid CustomerPurchasedId { get; set; }
     public double? TargetBiceps { get; set; }
     public double? TargetForeArm { get; set; }
     public double? TargetThigh { get; set; }

--- a/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommandHandler.cs
+++ b/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommandHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using AutoMapper;
 using FitBridge_Domain.Entities.Trainings;
 using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Entities.Gyms;
 
 namespace FitBridge_Application.Features.UserGoals.UpdateUserGoals;
 
@@ -12,7 +13,12 @@ public class UpdateUserGoalCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
 {
     public async Task<UserGoalsDto> Handle(UpdateUserGoalCommand request, CancellationToken cancellationToken)
     {
-        var userGoal = await _unitOfWork.Repository<UserGoal>().GetByIdAsync(request.Id);
+        var customerPurchased = await _unitOfWork.Repository<CustomerPurchased>().GetByIdAsync(request.CustomerPurchasedId, false, new List<string> { "UserGoal" });
+        if (customerPurchased == null)
+        {
+            throw new NotFoundException("Customer purchased not found");
+        }
+        var userGoal = customerPurchased.UserGoal;
         if (userGoal == null)
         {
             throw new NotFoundException("User goal not found");
@@ -52,7 +58,6 @@ public class UpdateUserGoalCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
         userGoal.ImageUrl = request.ImageUrl ?? userGoal.ImageUrl;
         userGoal.FinalImageUrl = request.FinalImageUrl ?? userGoal.FinalImageUrl;
         
-        _unitOfWork.Repository<UserGoal>().Update(userGoal);
         await _unitOfWork.CommitAsync();
         return _mapper.Map<UserGoal, UserGoalsDto>(userGoal);
     }


### PR DESCRIPTION
Updated UserGoalsController, related commands, queries, and handlers to use CustomerPurchasedId instead of Id for user goal operations. Improved entity retrieval logic and error handling for cases where CustomerPurchased is not found. This change aligns user goal management with the CustomerPurchased entity relationship.