### PR TITLE
#203 Add latitude and longitude to RegisterGymPtCommand

### DIFF
--- a/FitBridge_Application/Features/Identities/Registers/RegisterGymPT/RegisterGymPtCommand.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterGymPT/RegisterGymPtCommand.cs
@@ -15,7 +15,8 @@ public class RegisterGymPtCommand : IRequest<CreateNewPTResponse>
         public string Password { get; set; } = null!;
 
         public string Email { get; set; } = null!;
-
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
         public CreateNewGymPTRequest CreateNewPT { get; set; } = null!;
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/FitBridge_Application/MappingProfiles/IdentityProfiles.cs
+++ b/FitBridge_Application/MappingProfiles/IdentityProfiles.cs
@@ -19,7 +19,9 @@ public class IdentityProfiles : Profile
             .ForMember(dest => dest.IsMale, opt => opt.MapFrom(src => src.CreateNewPT.IsMale))
             .ForMember(dest => dest.GoalTrainings, opt => opt.MapFrom(src => src.CreateNewPT.GoalTrainings.Select(gt => new GoalTraining { Name = gt }).ToList()))
             .ForMember(dest => dest.EmailConfirmed, opt => opt.MapFrom(src => true))
-            .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => Guid.Parse(src.GymOwnerId ?? Guid.Empty.ToString())));
+            .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => Guid.Parse(src.GymOwnerId ?? Guid.Empty.ToString())))
+            .ForMember(dest => dest.Latitude, opt => opt.MapFrom(src => src.Latitude ?? null))
+            .ForMember(dest => dest.Longitude, opt => opt.MapFrom(src => src.Longitude ?? null));
 
         CreateMap<RegisterGymPtCommand, CreateNewPTResponse>()
             .ForMember(dest => dest.Phone, opt => opt.MapFrom(src => src.Phone))

--- a/FitBridge_Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/FitBridge_Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -118,18 +118,6 @@ namespace FitBridge_Infrastructure.Extensions
 
                 var disableExpiredCouponsJobKey = new JobKey("DisableExpiredCouponsJob");
 
-                q.UsePersistentStore(store =>
-                {
-                    store.UseProperties = true;
-                    store.UsePostgres(postgres =>
-                    {
-                        ArgumentException.ThrowIfNullOrEmpty(configuration.GetConnectionString("FitbridgeDb"));
-                        postgres.ConnectionString = configuration.GetConnectionString("FitbridgeDb")!;
-                        postgres.TablePrefix = "public.qrtz_";
-                    });
-                    store.UseSystemTextJsonSerializer();
-                });
-
                 q.AddJob<DisableExpiredCouponsJob>(opts => opts.WithIdentity(disableExpiredCouponsJobKey));
                 q.AddTrigger(opts => opts
                     .ForJob(disableExpiredCouponsJobKey)
@@ -148,8 +136,8 @@ namespace FitBridge_Infrastructure.Extensions
                 {
                     store.UsePostgres(postgres =>
                     {
-                        postgres.ConnectionString = configuration.GetConnectionString("FitBridgeDb");
-                        postgres.TablePrefix = "qrtz_";
+                        postgres.ConnectionString = configuration.GetConnectionString("FitbridgeDb");
+                        postgres.TablePrefix = "public.qrtz_";
                     });
                     store.UseNewtonsoftJsonSerializer();
                     store.UseClustering();


### PR DESCRIPTION
Introduces optional Latitude and Longitude properties to RegisterGymPtCommand and updates IdentityProfiles mapping to include these fields. Also refactors ServiceCollectionExtensions to unify Quartz persistent store configuration and corrects table prefix usage.