### PR TITLE
#203 Add body measurement record feature

### DIFF
--- a/FitBridge_API/Controllers/BodyMeasurementsController.cs
+++ b/FitBridge_API/Controllers/BodyMeasurementsController.cs
@@ -1,0 +1,45 @@
+using System;
+using FitBridge_API.Helpers.RequestHelpers;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using FitBridge_Application.Features.BodyMeasurements.CreateBodyMeasurement;
+using FitBridge_Application.Features.BodyMeasurements.DeleteBodyMeasurement;
+using FitBridge_Application.Features.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+using FitBridge_Application.Features.BodyMeasurements.UpdateBodyMeasurement;
+using FitBridge_Application.Specifications.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FitBridge_API.Controllers;
+
+public class BodyMeasurementsController(IMediator _mediator) : _BaseApiController
+{
+    [HttpPost]
+    public async Task<IActionResult> CreateBodyMeasurement([FromBody] CreateBodyMeasurementCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<string>(StatusCodes.Status200OK.ToString(), "Body measurement created successfully", result));
+    }
+
+    [HttpGet("{customerPurchasedId}")]
+    public async Task<IActionResult> GetBodyMeasurements([FromRoute] Guid customerPurchasedId, [FromQuery] GetBodyMeasurementRecordsByCustomerPurchasedIdParams parameters)
+    {
+        var result = await _mediator.Send(new GetBodyMeasurementRecordsByCustomerPurchasedIdQuery { Params = parameters, CustomerPurchasedId = customerPurchasedId });
+        var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
+        return Ok(new BaseResponse<Pagination<BodyMeasurementRecordDto>>(StatusCodes.Status200OK.ToString(), "Body measurements retrieved successfully", pagination));
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateBodyMeasurement([FromRoute] Guid id, [FromBody] UpdateBodyMeasurementCommand command)
+    {
+        command.Id = id;
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<BodyMeasurementRecordDto>(StatusCodes.Status200OK.ToString(), "Body measurement updated successfully", result));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteBodyMeasurement([FromRoute] Guid id)
+    {
+        var result = await _mediator.Send(new DeleteBodyMeasurementCommand { Id = id });
+        return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Body measurement deleted successfully", result));
+    }
+}

--- a/FitBridge_Application/Dtos/BodyMeasurements/BodyMeasurementRecordDto.cs
+++ b/FitBridge_Application/Dtos/BodyMeasurements/BodyMeasurementRecordDto.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace FitBridge_Application.Dtos.BodyMeasurements;
+
+public class BodyMeasurementRecordDto
+{
+    public Guid Id { get; set; }
+    public double? Biceps { get; set; }
+    public double? ForeArm { get; set; }
+    public double? Thigh { get; set; }
+    public double? Calf { get; set; }
+    public double? Chest { get; set; }
+    public double? Waist { get; set; }
+    public double? Hip { get; set; }
+    public double? Shoulder { get; set; }
+    public double? Height { get; set; }
+    public double? Weight { get; set; }
+    public Guid CustomerPurchasedId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/FitBridge_Application/Dtos/UserGoals/UserGoalsDto.cs
+++ b/FitBridge_Application/Dtos/UserGoals/UserGoalsDto.cs
@@ -25,18 +25,6 @@ public class UserGoalsDto
     public double? StartShoulder { get; set; }
     public double? StartHeight { get; set; }
     public double? StartWeight { get; set; }
-
-    public double? CurrentBiceps { get; set; }
-    public double? CurrentForeArm { get; set; }
-    public double? CurrentThigh { get; set; }
-    public double? CurrentCalf { get; set; }
-    public double? CurrentChest { get; set; }
-    public double? CurrentWaist { get; set; }
-    public double? CurrentHip { get; set; }
-    public double? CurrentShoulder { get; set; }
-    public double? CurrentHeight { get; set; }
-    public double? CurrentWeight { get; set; }
-
     public string? ImageUrl { get; set; }
     public string? FinalImageUrl { get; set; }
 }

--- a/FitBridge_Application/Features/BodyMeasurements/CreateBodyMeasurement/CreateBodyMeasurementCommand.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/CreateBodyMeasurement/CreateBodyMeasurementCommand.cs
@@ -1,0 +1,20 @@
+using System;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using MediatR;
+
+namespace FitBridge_Application.Features.BodyMeasurements.CreateBodyMeasurement;
+
+public class CreateBodyMeasurementCommand : IRequest<string>      
+{
+    public double? Biceps { get; set; }
+    public double? ForeArm { get; set; }
+    public double? Thigh { get; set; }
+    public double? Calf { get; set; }
+    public double? Chest { get; set; }
+    public double? Waist { get; set; }
+    public double? Hip { get; set; }
+    public double? Shoulder { get; set; }
+    public double? Height { get; set; }
+    public double? Weight { get; set; }
+    public Guid CustomerPurchasedId { get; set; }
+}

--- a/FitBridge_Application/Features/BodyMeasurements/CreateBodyMeasurement/CreateBodyMeasurementCommandHandler.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/CreateBodyMeasurement/CreateBodyMeasurementCommandHandler.cs
@@ -1,0 +1,49 @@
+using System;
+using AutoMapper;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using FitBridge_Application.Interfaces.Repositories;
+using MediatR;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Entities.Gyms;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Entities.Accounts;
+
+namespace FitBridge_Application.Features.BodyMeasurements.CreateBodyMeasurement;
+
+public class CreateBodyMeasurementCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<CreateBodyMeasurementCommand, string>
+{
+    public async Task<string> Handle(CreateBodyMeasurementCommand request, CancellationToken cancellationToken)
+    {
+        var customerPurchased = await _unitOfWork.Repository<CustomerPurchased>().GetByIdAsync(request.CustomerPurchasedId);
+        if (customerPurchased == null)
+        {
+            throw new NotFoundException("Customer purchased not found");
+        }
+        if(customerPurchased.ExpirationDate < DateOnly.FromDateTime(DateTime.UtcNow))
+        {
+            throw new BusinessException("Customer purchased expired");
+        }
+        var bodyMeasurementRecord = _mapper.Map<CreateBodyMeasurementCommand, BodyMeasurementRecord>(request);
+        var userDetail = await _unitOfWork.Repository<UserDetail>().GetByIdAsync(customerPurchased.CustomerId);
+        if (userDetail == null)
+        {
+            throw new NotFoundException("User detail not found");
+        }
+        userDetail.Biceps = request.Biceps ?? userDetail.Biceps;
+        userDetail.ForeArm = request.ForeArm ?? userDetail.ForeArm;
+        userDetail.Thigh = request.Thigh ?? userDetail.Thigh;
+        userDetail.Calf = request.Calf ?? userDetail.Calf;
+        userDetail.Chest = request.Chest ?? userDetail.Chest;
+        userDetail.Waist = request.Waist ?? userDetail.Waist;
+        userDetail.Hip = request.Hip ?? userDetail.Hip;
+        userDetail.Shoulder = request.Shoulder ?? userDetail.Shoulder;
+        userDetail.Height = request.Height ?? userDetail.Height;
+        userDetail.Weight = request.Weight ?? userDetail.Weight;
+        userDetail.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<UserDetail>().Update(userDetail);
+        _unitOfWork.Repository<BodyMeasurementRecord>().Insert(bodyMeasurementRecord);
+        await _unitOfWork.CommitAsync();
+        return bodyMeasurementRecord.Id.ToString();
+    }
+
+}

--- a/FitBridge_Application/Features/BodyMeasurements/DeleteBodyMeasurement/DeleteBodyMeasurementCommand.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/DeleteBodyMeasurement/DeleteBodyMeasurementCommand.cs
@@ -1,0 +1,9 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.BodyMeasurements.DeleteBodyMeasurement;
+
+public class DeleteBodyMeasurementCommand : IRequest<bool>      
+{
+    public Guid Id { get; set; }
+}

--- a/FitBridge_Application/Features/BodyMeasurements/DeleteBodyMeasurement/DeleteBodyMeasurementCommandHandler.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/DeleteBodyMeasurement/DeleteBodyMeasurementCommandHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using MediatR;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Exceptions;
+
+namespace FitBridge_Application.Features.BodyMeasurements.DeleteBodyMeasurement;
+
+public class DeleteBodyMeasurementCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<DeleteBodyMeasurementCommand, bool>
+{
+    public async Task<bool> Handle(DeleteBodyMeasurementCommand request, CancellationToken cancellationToken)
+    {
+        var bodyMeasurementRecord = await _unitOfWork.Repository<BodyMeasurementRecord>().GetByIdAsync(request.Id);
+        if (bodyMeasurementRecord == null)
+        {
+            throw new NotFoundException("Body measurement record not found");
+        }
+        _unitOfWork.Repository<BodyMeasurementRecord>().Delete(bodyMeasurementRecord);
+        await _unitOfWork.CommitAsync();
+        return true;
+    }
+
+}

--- a/FitBridge_Application/Features/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedIdQuery.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedIdQuery.cs
@@ -1,0 +1,14 @@
+using System;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using FitBridge_Application.Specifications.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+using MediatR;
+
+namespace FitBridge_Application.Features.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+
+public class GetBodyMeasurementRecordsByCustomerPurchasedIdQuery : IRequest<PagingResultDto<BodyMeasurementRecordDto>>
+{
+    public GetBodyMeasurementRecordsByCustomerPurchasedIdParams Params { get; set; }
+    public Guid CustomerPurchasedId { get; set; }
+
+}

--- a/FitBridge_Application/Features/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedIdQueryHandler.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedIdQueryHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using AutoMapper;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Specifications.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+using FitBridge_Domain.Entities.Trainings;
+using MediatR;
+
+namespace FitBridge_Application.Features.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+
+public class GetBodyMeasurementRecordsByCustomerPurchasedIdQueryHandler(IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<GetBodyMeasurementRecordsByCustomerPurchasedIdQuery, PagingResultDto<BodyMeasurementRecordDto>>
+{
+    public async Task<PagingResultDto<BodyMeasurementRecordDto>> Handle(GetBodyMeasurementRecordsByCustomerPurchasedIdQuery request, CancellationToken cancellationToken)
+    {
+        var spec = new GetBodyMeasurementRecordsByCustomerPurchasedSpec(request.Params, request.CustomerPurchasedId);
+        var records = await _unitOfWork.Repository<BodyMeasurementRecord>().GetAllWithSpecificationAsync(spec);
+        var results = _mapper.Map<IReadOnlyList<BodyMeasurementRecordDto>>(records);
+        var totalItems = await _unitOfWork.Repository<BodyMeasurementRecord>().CountAsync(spec);
+        return new PagingResultDto<BodyMeasurementRecordDto>(totalItems, results);
+    }
+
+}

--- a/FitBridge_Application/Features/BodyMeasurements/UpdateBodyMeasurement/UpdateBodyMeasurementCommand.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/UpdateBodyMeasurement/UpdateBodyMeasurementCommand.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text.Json.Serialization;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using MediatR;
+
+namespace FitBridge_Application.Features.BodyMeasurements.UpdateBodyMeasurement;
+
+public class UpdateBodyMeasurementCommand : IRequest<BodyMeasurementRecordDto>
+{
+    [JsonIgnore]
+    public Guid Id { get; set; }
+    public double? Biceps { get; set; }
+    public double? ForeArm { get; set; }
+    public double? Thigh { get; set; }
+    public double? Calf { get; set; }
+    public double? Chest { get; set; }
+    public double? Waist { get; set; }
+    public double? Hip { get; set; }
+    public double? Shoulder { get; set; }
+    public double? Height { get; set; }
+    public double? Weight { get; set; }
+}

--- a/FitBridge_Application/Features/BodyMeasurements/UpdateBodyMeasurement/UpdateBodyMeasurementCommandHandler.cs
+++ b/FitBridge_Application/Features/BodyMeasurements/UpdateBodyMeasurement/UpdateBodyMeasurementCommandHandler.cs
@@ -1,0 +1,68 @@
+using System;
+using AutoMapper;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Specifications.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+using MediatR;
+using FitBridge_Domain.Entities.Trainings;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Entities.Accounts;
+using FitBridge_Domain.Entities.Gyms;
+
+namespace FitBridge_Application.Features.BodyMeasurements.UpdateBodyMeasurement;
+
+public class UpdateBodyMeasurementCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapper) : IRequestHandler<UpdateBodyMeasurementCommand, BodyMeasurementRecordDto>
+{
+    public async Task<BodyMeasurementRecordDto> Handle(UpdateBodyMeasurementCommand request, CancellationToken cancellationToken)
+    {
+        var bodyMeasurementRecord = await _unitOfWork.Repository<BodyMeasurementRecord>().GetByIdAsync(request.Id);
+        var allBodyMeasurementRecords = await _unitOfWork.Repository<BodyMeasurementRecord>().GetAllWithSpecificationAsync(new GetBodyMeasurementRecordsByCustomerPurchasedSpec(new GetBodyMeasurementRecordsByCustomerPurchasedIdParams { DoApplyPaging = false }, bodyMeasurementRecord.CustomerPurchasedId));
+
+        var latestBodyMeasurementRecord = allBodyMeasurementRecords.OrderByDescending(x => x.CreatedAt).FirstOrDefault();
+        if (bodyMeasurementRecord.CreatedAt == latestBodyMeasurementRecord.CreatedAt)
+        {
+            await UpdateUserDetailByLatestBodyMeasurementRecord(bodyMeasurementRecord.CustomerPurchasedId, request);
+        }
+        bodyMeasurementRecord.Biceps = request.Biceps ?? bodyMeasurementRecord.Biceps;
+        bodyMeasurementRecord.ForeArm = request.ForeArm ?? bodyMeasurementRecord.ForeArm;
+        bodyMeasurementRecord.Thigh = request.Thigh ?? bodyMeasurementRecord.Thigh;
+        bodyMeasurementRecord.Calf = request.Calf ?? bodyMeasurementRecord.Calf;
+        bodyMeasurementRecord.Chest = request.Chest ?? bodyMeasurementRecord.Chest;
+        bodyMeasurementRecord.Waist = request.Waist ?? bodyMeasurementRecord.Waist;
+        bodyMeasurementRecord.Hip = request.Hip ?? bodyMeasurementRecord.Hip;
+        bodyMeasurementRecord.Shoulder = request.Shoulder ?? bodyMeasurementRecord.Shoulder;
+        bodyMeasurementRecord.Height = request.Height ?? bodyMeasurementRecord.Height;
+        bodyMeasurementRecord.Weight = request.Weight ?? bodyMeasurementRecord.Weight;
+        bodyMeasurementRecord.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<BodyMeasurementRecord>().Update(bodyMeasurementRecord);
+        await _unitOfWork.CommitAsync();
+        return _mapper.Map<BodyMeasurementRecordDto>(bodyMeasurementRecord);
+    }
+
+    public async Task UpdateUserDetailByLatestBodyMeasurementRecord(Guid customerPurchasedId, UpdateBodyMeasurementCommand request)
+    {
+        var customerPurchased = await _unitOfWork.Repository<CustomerPurchased>().GetByIdAsync(customerPurchasedId);
+        if (customerPurchased == null)
+        {
+            throw new NotFoundException("Customer purchased not found");
+        }
+        var customerId = customerPurchased.CustomerId;
+        var userDetail = await _unitOfWork.Repository<UserDetail>().GetByIdAsync(customerId);
+        if (userDetail == null)
+        {
+            throw new NotFoundException("User detail not found");
+        }
+        userDetail.Biceps = request.Biceps ?? userDetail.Biceps;
+        userDetail.ForeArm = request.ForeArm ?? userDetail.ForeArm;
+        userDetail.Thigh = request.Thigh ?? userDetail.Thigh;
+        userDetail.Calf = request.Calf ?? userDetail.Calf;
+        userDetail.Chest = request.Chest ?? userDetail.Chest;
+        userDetail.Waist = request.Waist ?? userDetail.Waist;
+        userDetail.Hip = request.Hip ?? userDetail.Hip;
+        userDetail.Shoulder = request.Shoulder ?? userDetail.Shoulder;
+        userDetail.Height = request.Height ?? userDetail.Height;
+        userDetail.Weight = request.Weight ?? userDetail.Weight;
+        userDetail.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<UserDetail>().Update(userDetail);
+    }
+}

--- a/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommandHandler.cs
+++ b/FitBridge_Application/Features/UserGoals/UpdateUserGoals/UpdateUserGoalCommandHandler.cs
@@ -71,16 +71,6 @@ public class UpdateUserGoalCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
         userGoal.StartHeight = request.StartHeight ?? userGoal.StartHeight;
         userGoal.StartWeight = request.StartWeight ?? userGoal.StartWeight;
 
-        userGoal.FinalBiceps = request.CurrentBiceps ?? userGoal.FinalBiceps;
-        userGoal.FinalForeArm = request.CurrentForeArm ?? userGoal.FinalForeArm;
-        userGoal.FinalThigh = request.CurrentThigh ?? userGoal.FinalThigh;
-        userGoal.FinalCalf = request.CurrentCalf ?? userGoal.FinalCalf;
-        userGoal.FinalChest = request.CurrentChest ?? userGoal.FinalChest;
-        userGoal.FinalWaist = request.CurrentWaist ?? userGoal.FinalWaist;
-        userGoal.FinalHip = request.CurrentHip ?? userGoal.FinalHip;
-        userGoal.FinalShoulder = request.CurrentShoulder ?? userGoal.FinalShoulder;
-        userGoal.FinalHeight = request.CurrentHeight ?? userGoal.FinalHeight;
-        userGoal.FinalWeight = request.CurrentWeight ?? userGoal.FinalWeight;
         userGoal.ImageUrl = request.ImageUrl ?? userGoal.ImageUrl;
         userGoal.FinalImageUrl = request.FinalImageUrl ?? userGoal.FinalImageUrl;
         

--- a/FitBridge_Application/MappingProfiles/BodyMeasurementMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/BodyMeasurementMappingProfile.cs
@@ -1,0 +1,16 @@
+using System;
+using AutoMapper;
+using FitBridge_Application.Dtos.BodyMeasurements;
+using FitBridge_Application.Features.BodyMeasurements.CreateBodyMeasurement;
+using FitBridge_Domain.Entities.Trainings;
+
+namespace FitBridge_Application.MappingProfiles;
+
+public class BodyMeasurementMappingProfile : Profile
+{
+    public BodyMeasurementMappingProfile()
+    {
+        CreateMap<BodyMeasurementRecord, BodyMeasurementRecordDto>();
+        CreateMap<CreateBodyMeasurementCommand, BodyMeasurementRecord>();
+    }
+}

--- a/FitBridge_Application/MappingProfiles/UserGoalsMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/UserGoalsMappingProfile.cs
@@ -11,16 +11,8 @@ public class UserGoalsMappingProfile : Profile
     public UserGoalsMappingProfile()
     {
         CreateMap<UserGoal, UserGoalsDto>()
-        .ForMember(dest => dest.CurrentBiceps, opt => opt.MapFrom(src => src.FinalBiceps))
-        .ForMember(dest => dest.CurrentForeArm, opt => opt.MapFrom(src => src.FinalForeArm))
-        .ForMember(dest => dest.CurrentThigh, opt => opt.MapFrom(src => src.FinalThigh))
-        .ForMember(dest => dest.CurrentCalf, opt => opt.MapFrom(src => src.FinalCalf))
-        .ForMember(dest => dest.CurrentChest, opt => opt.MapFrom(src => src.FinalChest))
-        .ForMember(dest => dest.CurrentWaist, opt => opt.MapFrom(src => src.FinalWaist))
-        .ForMember(dest => dest.CurrentHip, opt => opt.MapFrom(src => src.FinalHip))
-        .ForMember(dest => dest.CurrentShoulder, opt => opt.MapFrom(src => src.FinalShoulder))
-        .ForMember(dest => dest.CurrentHeight, opt => opt.MapFrom(src => src.FinalHeight))
-        .ForMember(dest => dest.CurrentWeight, opt => opt.MapFrom(src => src.FinalWeight));
+        .ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.ImageUrl))
+        .ForMember(dest => dest.FinalImageUrl, opt => opt.MapFrom(src => src.FinalImageUrl));
         
         CreateMap<CreateUserGoalCommand, UserGoal>();
     }

--- a/FitBridge_Application/Specifications/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedIdParams.cs
+++ b/FitBridge_Application/Specifications/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedIdParams.cs
@@ -1,0 +1,8 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace FitBridge_Application.Specifications.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+
+public class GetBodyMeasurementRecordsByCustomerPurchasedIdParams : BaseParams
+{
+}

--- a/FitBridge_Application/Specifications/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedSpec.cs
+++ b/FitBridge_Application/Specifications/BodyMeasurements/GetBodyMeasurementRecordsByCustomerPurchasedId/GetBodyMeasurementRecordsByCustomerPurchasedSpec.cs
@@ -1,0 +1,22 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.Trainings;
+
+namespace FitBridge_Application.Specifications.BodyMeasurements.GetBodyMeasurementRecordsByCustomerPurchasedId;
+
+public class GetBodyMeasurementRecordsByCustomerPurchasedSpec : BaseSpecification<BodyMeasurementRecord>
+{
+    public GetBodyMeasurementRecordsByCustomerPurchasedSpec(GetBodyMeasurementRecordsByCustomerPurchasedIdParams parameters, Guid customerPurchasedId) : base(x => x.CustomerPurchasedId == customerPurchasedId)
+    {
+        AddOrderByDesc(x => x.CreatedAt);
+        if (parameters.DoApplyPaging)
+        {
+            AddPaging(parameters.Size * (parameters.Page - 1), parameters.Size);
+        }
+        else
+        {
+            parameters.Size = -1;
+            parameters.Page = -1;
+        }
+    }
+}

--- a/FitBridge_Domain/Entities/Gyms/CustomerPurchased.cs
+++ b/FitBridge_Domain/Entities/Gyms/CustomerPurchased.cs
@@ -14,6 +14,7 @@ public class CustomerPurchased : BaseEntity
     public ICollection<OrderItem> OrderItems { get; set; } = new List<OrderItem>();
     public UserGoal? UserGoal { get; set; }
     public ICollection<Booking> Bookings { get; set; } = new List<Booking>();
+    public ICollection<BodyMeasurementRecord> BodyMeasurementRecords { get; set; } = new List<BodyMeasurementRecord>();
     public ICollection<Order> OrderThatExtend { get; set; } = new List<Order>();
     public ICollection<BookingRequest> BookingRequests { get; set; } = new List<BookingRequest>();
 }

--- a/FitBridge_Domain/Entities/Trainings/BodyMeasurementRecord.cs
+++ b/FitBridge_Domain/Entities/Trainings/BodyMeasurementRecord.cs
@@ -1,0 +1,19 @@
+using System;
+using FitBridge_Domain.Entities.Gyms;
+namespace FitBridge_Domain.Entities.Trainings;
+
+public class BodyMeasurementRecord : BaseEntity
+{
+    public double? Biceps { get; set; }
+    public double? ForeArm { get; set; }
+    public double? Thigh { get; set; }
+    public double? Calf { get; set; }
+    public double? Chest { get; set; }
+    public double? Waist { get; set; }
+    public double? Hip { get; set; }
+    public double? Shoulder { get; set; }
+    public double? Height { get; set; }
+    public double? Weight { get; set; }
+    public Guid CustomerPurchasedId { get; set; }
+    public CustomerPurchased CustomerPurchased { get; set; }
+}

--- a/FitBridge_Domain/Entities/Trainings/UserGoal.cs
+++ b/FitBridge_Domain/Entities/Trainings/UserGoal.cs
@@ -28,18 +28,6 @@ public class UserGoal : BaseEntity
     public double? StartShoulder { get; set; }
     public double? StartHeight { get; set; }
     public double? StartWeight { get; set; }
-
-    public double? FinalBiceps { get; set; }
-    public double? FinalForeArm { get; set; }
-    public double? FinalThigh { get; set; }
-    public double? FinalCalf { get; set; }
-    public double? FinalChest { get; set; }
-    public double? FinalWaist { get; set; }
-    public double? FinalHip { get; set; }
-    public double? FinalShoulder { get; set; }
-    public double? FinalHeight { get; set; }
-    public double? FinalWeight { get; set; }
-
     public string? ImageUrl { get; set; }
     public string? FinalImageUrl { get; set; }
     public Guid CustomerPurchasedId { get; set; }

--- a/FitBridge_Infrastructure/Configurations/BodyMeasurementRecordConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/BodyMeasurementRecordConfiguration.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using FitBridge_Domain.Entities.Trainings;
+
+namespace FitBridge_Infrastructure.Configurations;
+
+public class BodyMeasurementRecordConfiguration : IEntityTypeConfiguration<BodyMeasurementRecord>
+{
+    public void Configure(EntityTypeBuilder<BodyMeasurementRecord> builder)
+    {
+        builder.ToTable("BodyMeasurementRecords");
+        builder.Property(e => e.Biceps).IsRequired(false);
+        builder.Property(e => e.ForeArm).IsRequired(false);
+        builder.Property(e => e.Thigh).IsRequired(false);
+        builder.Property(e => e.Calf).IsRequired(false);
+        builder.Property(e => e.Chest).IsRequired(false);
+        builder.Property(e => e.Waist).IsRequired(false);
+        builder.Property(e => e.Hip).IsRequired(false);
+        builder.Property(e => e.Shoulder).IsRequired(false);
+        builder.Property(e => e.Height).IsRequired(false);
+        builder.Property(e => e.Weight).IsRequired(false);
+        builder.Property(e => e.CustomerPurchasedId).IsRequired();
+
+        builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.IsEnabled).HasDefaultValue(true);
+        builder.HasOne(e => e.CustomerPurchased).WithMany(e => e.BodyMeasurementRecords).HasForeignKey(e => e.CustomerPurchasedId);
+    }
+}

--- a/FitBridge_Infrastructure/Configurations/UserGoalConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/UserGoalConfiguration.cs
@@ -31,16 +31,6 @@ public class UserGoalConfiguration : IEntityTypeConfiguration<UserGoal>
         builder.Property(e => e.StartHeight).IsRequired(false);
         builder.Property(e => e.StartWeight).IsRequired(false);
 
-        builder.Property(e => e.FinalBiceps).IsRequired(false);
-        builder.Property(e => e.FinalForeArm).IsRequired(false);
-        builder.Property(e => e.FinalThigh).IsRequired(false);
-        builder.Property(e => e.FinalCalf).IsRequired(false);
-        builder.Property(e => e.FinalChest).IsRequired(false);
-        builder.Property(e => e.FinalWaist).IsRequired(false);
-        builder.Property(e => e.FinalHip).IsRequired(false);
-        builder.Property(e => e.FinalShoulder).IsRequired(false);
-        builder.Property(e => e.FinalHeight).IsRequired(false);
-        builder.Property(e => e.FinalWeight).IsRequired(false);
         builder.Property(e => e.ImageUrl).IsRequired(false);
         builder.Property(e => e.CustomerPurchasedId).IsRequired(true);
 


### PR DESCRIPTION
Introduces body measurement record management, including API controller, DTOs, domain entity, mapping profiles, and related application logic for create, update, delete, and query operations. Removes 'current' and 'final' measurement fields from user goals, updates mapping profiles and configurations accordingly, and establishes relationships between customer purchases and body measurement records.