### PR TITLE
#203 Add CustomerId filter to freelance PT customers spec

### DIFF
--- a/FitBridge_Application/Specifications/Accounts/GetFreelancePtCustomers/GetFreelancePtCustomersParams.cs
+++ b/FitBridge_Application/Specifications/Accounts/GetFreelancePtCustomers/GetFreelancePtCustomersParams.cs
@@ -2,5 +2,6 @@
 {
     public class GetFreelancePtCustomerParams : BaseParams
     {
+        public Guid? CustomerId { get; set; }
     }
 }

--- a/FitBridge_Application/Specifications/Accounts/GetFreelancePtCustomers/GetFreelancePtCustomersSpec.cs
+++ b/FitBridge_Application/Specifications/Accounts/GetFreelancePtCustomers/GetFreelancePtCustomersSpec.cs
@@ -11,7 +11,7 @@ namespace FitBridge_Application.Specifications.Accounts.GetFreelancePtCustomers
             && (string.IsNullOrEmpty(parameters.SearchTerm) ||
             x.FullName.ToLower().Contains(parameters.SearchTerm.ToLower()) ||
             x.Email.ToLower().Contains(parameters.SearchTerm.ToLower()))
-        )
+            && (parameters.CustomerId == null || x.Id == parameters.CustomerId))
         {
             if (parameters.DoApplyPaging)
             {


### PR DESCRIPTION
Introduced an optional CustomerId parameter to GetFreelancePtCustomerParams and updated GetFreelancePtCustomersSpec to filter results by CustomerId when provided. This allows more precise querying of freelance PT customers.