### PR TITLE
Refactor account ban validation and customer spec

### DIFF
--- a/FitBridge_Application/Specifications/Accounts/GetFreelancePtCustomers/GetFreelancePtCustomersSpec.cs
+++ b/FitBridge_Application/Specifications/Accounts/GetFreelancePtCustomers/GetFreelancePtCustomersSpec.cs
@@ -6,8 +6,8 @@ namespace FitBridge_Application.Specifications.Accounts.GetFreelancePtCustomers
     public class GetFreelancePtCustomersSpec : BaseSpecification<ApplicationUser>
     {
         public GetFreelancePtCustomersSpec(Guid freelancePtId, GetFreelancePtCustomerParams parameters) : base(x =>
-            x.Orders.Any(x => x.OrderItems.Any(oi => oi.FreelancePTPackageId != null
-            && oi.FreelancePTPackage!.PtId == freelancePtId))
+            x.CustomerPurchased.Any(cp => cp.OrderItems.Any(oi => oi.FreelancePTPackageId != null
+                                                                && oi.FreelancePTPackage!.PtId == freelancePtId))
             && (string.IsNullOrEmpty(parameters.SearchTerm) ||
             x.FullName.ToLower().Contains(parameters.SearchTerm.ToLower()) ||
             x.Email.ToLower().Contains(parameters.SearchTerm.ToLower()))


### PR DESCRIPTION
Simplified account ban validation by removing command type checks and handling null account IDs. Updated GetFreelancePtCustomersSpec to use CustomerPurchased instead of Orders for filtering freelance PT customers.
