### PR TITLE
Add report notification models and handlers

### DIFF
--- a/FitBridge_Application/Dtos/Templates/NewReportModel.cs
+++ b/FitBridge_Application/Dtos/Templates/NewReportModel.cs
@@ -1,0 +1,13 @@
+namespace FitBridge_Application.Dtos.Templates
+{
+    public class NewReportModel : IBaseTemplateModel
+    {
+        public string TitleReporterName { get; set; }
+
+        public string BodyReporterName { get; set; }
+
+        public string BodyReportTitle { get; set; }
+
+        public string BodyReportType { get; set; }
+    }
+}

--- a/FitBridge_Application/Dtos/Templates/ReportStatusUpdatedModel.cs
+++ b/FitBridge_Application/Dtos/Templates/ReportStatusUpdatedModel.cs
@@ -1,0 +1,13 @@
+namespace FitBridge_Application.Dtos.Templates
+{
+    public class ReportStatusUpdatedModel : IBaseTemplateModel
+    {
+        public string TitleReportTitle { get; set; }
+
+        public string BodyReportTitle { get; set; }
+
+        public string BodyStatus { get; set; }
+
+        public string BodyNote { get; set; }
+    }
+}

--- a/FitBridge_Application/Features/Reports/UpdateReportStatus/UpdateReportStatusCommandHandler.cs
+++ b/FitBridge_Application/Features/Reports/UpdateReportStatus/UpdateReportStatusCommandHandler.cs
@@ -1,13 +1,19 @@
-﻿using FitBridge_Application.Interfaces.Repositories;
+﻿using FitBridge_Application.Dtos.Notifications;
+using FitBridge_Application.Dtos.Templates;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Interfaces.Services.Notifications;
 using FitBridge_Domain.Entities.Reports;
+using FitBridge_Domain.Enums.MessageAndReview;
 using FitBridge_Domain.Enums.Reports;
 using FitBridge_Domain.Exceptions;
 using MediatR;
+using System.Text.Json;
 
 namespace FitBridge_Application.Features.Reports.UpdateReportStatus
 {
     internal class UpdateReportStatusCommandHandler(
-        IUnitOfWork unitOfWork) : IRequestHandler<UpdateReportStatusCommand>
+        IUnitOfWork unitOfWork,
+        INotificationService notificationService) : IRequestHandler<UpdateReportStatusCommand>
     {
         public async Task Handle(UpdateReportStatusCommand request, CancellationToken cancellationToken)
         {
@@ -32,6 +38,36 @@ namespace FitBridge_Application.Features.Reports.UpdateReportStatus
 
             unitOfWork.Repository<ReportCases>().Update(existingReport);
             await unitOfWork.CommitAsync();
+
+            await SendNotificationToReporter(existingReport);
+        }
+
+        private async Task SendNotificationToReporter(ReportCases report)
+        {
+            var statusMessage = report.Status switch
+            {
+                ReportCaseStatus.Pending => "Pending Review",
+                ReportCaseStatus.Processing => "Under Investigation",
+                ReportCaseStatus.Resolved => "Resolved",
+                ReportCaseStatus.FraudConfirmed => "Fraud Confirmed",
+                _ => report.Status.ToString()
+            };
+
+            var model = new ReportStatusUpdatedModel
+            {
+                TitleReportTitle = report.Title,
+                BodyReportTitle = report.Title,
+                BodyStatus = statusMessage,
+                BodyNote = report.Note ?? "No additional notes provided."
+            };
+
+            var notificationMessage = new NotificationMessage(
+                EnumContentType.ReportStatusUpdated,
+                [report.ReporterId],
+                model,
+                JsonSerializer.Serialize(new { report.Id }));
+
+            await notificationService.NotifyUsers(notificationMessage);
         }
     }
 }

--- a/FitBridge_Domain/Enums/MessageAndReview/EnumContentType.cs
+++ b/FitBridge_Domain/Enums/MessageAndReview/EnumContentType.cs
@@ -34,5 +34,10 @@
         RejectBookingRequest, // Customer/FreelancePT reject a booking request
 
         AcceptBookingRequest, // Customer/FreelancePT accept a booking request
+
+        // Reports
+        NewReport, // Customer creates a new report case
+
+        ReportStatusUpdated, // Admin updates report status
     }
 }


### PR DESCRIPTION
Introduced NewReportModel and ReportStatusUpdatedModel DTOs for report-related notifications. Updated CreateReportCommandHandler and UpdateReportStatusCommandHandler to send notifications to admins and reporters respectively. Extended EnumContentType with NewReport and ReportStatusUpdated values to support new notification types.
