### PR TITLE
#231 Add Apple webhook support and location to registration

### DIFF
--- a/FitBridge_API/Controllers/PaymentsController.cs
+++ b/FitBridge_API/Controllers/PaymentsController.cs
@@ -47,6 +47,16 @@ public class PaymentsController(IMediator _mediator) : _BaseApiController
         return BadRequest(new BaseResponse<bool>(StatusCodes.Status400BadRequest.ToString(), "Failed to process webhook", result));
     }
 
+    [HttpPost("apple-webhook")]
+    [AllowAnonymous]
+    public async Task<IActionResult> AppleWebhook()
+    {
+        using var reader = new StreamReader(Request.Body);
+        var webhookData = await reader.ReadToEndAsync();
+        var spec = new AppleWebhookCommand { WebhookData = webhookData };
+        var result = await _mediator.Send(spec);
+    }
+
     [HttpGet("{id}")]
     [Authorize]
     public async Task<IActionResult> GetPaymentInfo(string id)

--- a/FitBridge_Application/Dtos/Payments/ApplePaymentDto/AppStoreServerNotificationV2.cs
+++ b/FitBridge_Application/Dtos/Payments/ApplePaymentDto/AppStoreServerNotificationV2.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Payments.ApplePaymentDto;
+
+public class AppStoreServerNotificationV2
+{
+    public string SignedPayload { get; init; } = default!;
+}

--- a/FitBridge_Application/Dtos/Payments/ApplePaymentDto/AsnData.cs
+++ b/FitBridge_Application/Dtos/Payments/ApplePaymentDto/AsnData.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Payments.ApplePaymentDto;
+
+public sealed class AsnData
+{
+    public long? AppAppleId { get; init; }
+    public string BundleId { get; init; } = default!;
+    public string? BundleVersion { get; init; }
+    public string Environment { get; init; } = default!;          
+    public string? ConsumptionRequestReason { get; init; }         
+    public string? SignedRenewalInfo { get; init; }                
+    public string SignedTransactionInfo { get; init; } = default!; 
+    public int? Status { get; init; }                              
+}

--- a/FitBridge_Application/Dtos/Payments/ApplePaymentDto/AsnDecodedPayload.cs
+++ b/FitBridge_Application/Dtos/Payments/ApplePaymentDto/AsnDecodedPayload.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Payments.ApplePaymentDto;
+
+public class AsnDecodedPayload
+{
+    public string NotificationType { get; init; } = default!;  
+    public string? Subtype { get; init; }                   
+    public AsnData Data { get; init; } = default!;
+    public string? ExternalPurchaseToken { get; init; }
+    public string Version { get; init; } = default!;          
+    public long SignedDate { get; init; }     
+    public Guid NotificationUUID { get; init; }
+}

--- a/FitBridge_Application/Dtos/Payments/ApplePaymentDto/JwsHeader.cs
+++ b/FitBridge_Application/Dtos/Payments/ApplePaymentDto/JwsHeader.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Payments.ApplePaymentDto;
+
+public class JwsHeader
+{
+    public string alg { get; init; } = default!;     
+    public string kid { get; init; } = default!;
+    public string[] x5c { get; init; } = default!;   
+}

--- a/FitBridge_Application/Dtos/Payments/ApplePaymentDto/JwsRenewalInfoDecoded.cs
+++ b/FitBridge_Application/Dtos/Payments/ApplePaymentDto/JwsRenewalInfoDecoded.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Payments.ApplePaymentDto;
+
+public class JwsRenewalInfoDecoded
+{
+    public string OriginalTransactionId { get; init; } = default!;
+    public string AutoRenewProductId { get; init; } = default!;
+    public bool AutoRenewStatus { get; init; }
+    public string? OfferIdentifier { get; init; }
+    public string? OfferType { get; init; }
+    public string? PriceIncreaseStatus { get; init; }                
+    public string Environment { get; init; } = default!;
+    public string? RecentSubscriptionStartDate { get; init; }
+    public string? RenewalDate { get; init; }
+}

--- a/FitBridge_Application/Dtos/Payments/ApplePaymentDto/JwsTransactionDecoded.cs
+++ b/FitBridge_Application/Dtos/Payments/ApplePaymentDto/JwsTransactionDecoded.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Payments.ApplePaymentDto;
+
+public class JwsTransactionDecoded
+{
+    public string TransactionId { get; init; } = default!;
+    public string OriginalTransactionId { get; init; } = default!;
+    public string BundleId { get; init; } = default!;
+    public string ProductId { get; init; } = default!;
+    public string? SubscriptionGroupIdentifier { get; init; }
+    public string InAppOwnershipType { get; init; } = default!;     
+    public string Type { get; init; } = default!;                    
+    public long PurchaseDate { get; init; }                          
+    public long? ExpiresDate { get; init; }                          
+    public bool? IsUpgraded { get; init; }
+    public string? OfferIdentifier { get; init; }
+    public string? OfferType { get; init; }                          
+    public string? Currency { get; init; }
+    public long? Price { get; init; }                                
+    public string Environment { get; init; } = default!;
+    public string? CountryCode { get; init; }
+}

--- a/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommand.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommand.cs
@@ -14,4 +14,6 @@ public class RegisterAccountCommand : IRequest<RegisterResponseDto>
     public string? TaxCode { get; set; }
     public string Role { get; set; }
     public bool IsTestAccount { get; set; } = false;
+    public double? Longitude { get; set; }
+    public double? Latitude { get; set; }
 }

--- a/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommandHandler.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommandHandler.cs
@@ -31,6 +31,8 @@ public class RegisterAccountCommandHandler(IApplicationUserService _applicationU
             Password = request.Password,
             GymName = request.GymName ?? "",
             TaxCode = request.TaxCode ?? "",
+            Longitude = request.Longitude,
+            Latitude = request.Latitude,
             EmailConfirmed = true,
         };
         await _applicationUserService.InsertUserAsync(user, request.Password);

--- a/FitBridge_Application/Features/Identities/Registers/RegisterCustomer/RegisterCommand.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterCustomer/RegisterCommand.cs
@@ -13,4 +13,6 @@ public class RegisterCommand : IRequest<RegisterResponseDto>
     public string Password { get; set; }
     public string FullName { get; set; }
     public bool IsTestAccount { get; set; } = false;
+    public double? Longitude { get; set; }
+    public double? Latitude { get; set; }
 }

--- a/FitBridge_Application/Features/Identities/Registers/RegisterCustomer/RegisterCommandHandler.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterCustomer/RegisterCommandHandler.cs
@@ -26,6 +26,8 @@ public class RegisterCommandHandler(IApplicationUserService _applicationUserServ
             FullName = request.FullName,
             Password = request.Password,
             EmailConfirmed = request.IsTestAccount,
+            Longitude = request.Longitude,
+            Latitude = request.Latitude,
         };
         await _applicationUserService.InsertUserAsync(user, request.Password);
         await _applicationUserService.AssignRoleAsync(user, ProjectConstant.UserRoles.Customer);

--- a/FitBridge_Application/Features/Payments/AppleWebhook/AppleWebhookCommand.cs
+++ b/FitBridge_Application/Features/Payments/AppleWebhook/AppleWebhookCommand.cs
@@ -1,0 +1,9 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.Payments.AppleWebhook;
+
+public class AppleWebhookCommand : IRequest<bool>
+{
+    public string WebhookData { get; set; } = string.Empty;
+}

--- a/FitBridge_Application/Features/Payments/AppleWebhook/AppleWebhookCommandHandler.cs
+++ b/FitBridge_Application/Features/Payments/AppleWebhook/AppleWebhookCommandHandler.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace FitBridge_Application.Features.Payments.AppleWebhook;
+
+public class AppleWebhookCommandHandler(IPayOSService _payOSService) : IRequestHandler<AppleWebhookCommand, bool>
+{
+
+}

--- a/FitBridge_Application/Interfaces/Services/IAppleNotificationServerService.cs
+++ b/FitBridge_Application/Interfaces/Services/IAppleNotificationServerService.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace FitBridge_Application.Interfaces.Services;
+
+public interface IAppleNotificationServerService
+{
+    Task<bool> HandleAppleWebhookAsync(string webhookData);
+}

--- a/FitBridge_Infrastructure/Services/AppleNotificationServerService.cs
+++ b/FitBridge_Infrastructure/Services/AppleNotificationServerService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using FitBridge_Application.Dtos.Payments.ApplePaymentDto;
+using FitBridge_Application.Interfaces.Services;
+using Microsoft.Extensions.Logging;
+
+namespace FitBridge_Infrastructure.Services;
+
+public class AppleNotificationServerService(ILogger<AppleNotificationServerService> _logger, IAppleNotificationServerService _appleNotificationServerService) : IAppleNotificationServerService
+{
+    public async Task<bool> HandleAppleWebhookAsync(string webhookData)
+    {
+        try
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            var decodedPayload = JsonSerializer.Deserialize<AppStoreServerNotificationV2>(webhookData, options);
+            if (decodedPayload == null)
+            {
+                _logger.LogWarning("Invalid webhook payload received");
+                return false;
+            }
+
+            var signedPayload = decodedPayload.SignedPayload;
+
+            var decodedSignedPayload = DecodeWithoutVerify(signedPayload);
+            var jwsHeader = decodedSignedPayload.header;
+            var asnDecodedPayload = decodedSignedPayload.body;
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling Apple webhook");
+            return false;
+        }
+    }
+
+    static byte[] Base64UrlDecode(string s)
+    {
+        s = s.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4) { case 2: s += "=="; break; case 3: s += "="; break; }
+        return Convert.FromBase64String(s);
+    }
+    public static (JwsHeader header, AsnDecodedPayload body) DecodeWithoutVerify(string signedPayload)
+    {
+        var parts = signedPayload.Split('.');
+        var headerJson = Encoding.UTF8.GetString(Base64UrlDecode(parts[0]));
+        var payloadJson = Encoding.UTF8.GetString(Base64UrlDecode(parts[1]));
+
+        var header = JsonSerializer.Deserialize<JwsHeader>(headerJson)!;
+        var body = JsonSerializer.Deserialize<AsnDecodedPayload>(payloadJson)!;
+        return (header, body);
+    }
+}


### PR DESCRIPTION
Introduced Apple webhook endpoint and related DTOs, command, handler, and service for processing App Store notifications. Added longitude and latitude fields to account and customer registration commands and handlers to support location data.