### PR TITLE
#203 Add GymOwnerName and Id fields to admin DTOs

### DIFF
--- a/FitBridge_Application/Dtos/Accounts/Customers/GetAllCustomersForAdminDto.cs
+++ b/FitBridge_Application/Dtos/Accounts/Customers/GetAllCustomersForAdminDto.cs
@@ -4,6 +4,7 @@ namespace FitBridge_Application.Dtos.Accounts.Customers;
 
 public class GetAllCustomersForAdminDto
 {
+    public Guid Id { get; set; }
     public string FullName { get; set; }
     public bool IsMale { get; set; }
     public DateTime Dob { get; set; }

--- a/FitBridge_Application/Dtos/Gym/GetAllGymPtsForAdminResponseDto.cs
+++ b/FitBridge_Application/Dtos/Gym/GetAllGymPtsForAdminResponseDto.cs
@@ -13,5 +13,6 @@ public class GetAllGymPtsForAdminResponseDto
     public string? AvatarUrl { get; set; }
     public int Experience { get; set; }
     public Guid? GymOwnerId { get; set; }
+    public string? GymOwnerName { get; set; }
     public bool IsActive { get; set; }
 }

--- a/FitBridge_Application/Dtos/Gym/GetGymPtsDetailForAdminResponseDto.cs
+++ b/FitBridge_Application/Dtos/Gym/GetGymPtsDetailForAdminResponseDto.cs
@@ -14,7 +14,7 @@ public class GetGymPtsDetailForAdminResponseDto
     public string? AvatarUrl { get; set; }
     public List<string> GoalTrainings { get; set; } = new List<string>();
     public Guid? GymOwnerId { get; set; }
-    public string? GymName { get; set; }
+    public string? GymOwnerName { get; set; }
     public UserDetailDto? UserDetail { get; set; }
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/FitBridge_Application/MappingProfiles/AccountMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/AccountMappingProfile.cs
@@ -65,6 +65,7 @@ public class AccountMappingProfile : Profile
             .ForMember(dest => dest.AvatarUrl, opt => opt.MapFrom(src => src.AvatarUrl))
             .ForMember(dest => dest.Experience, opt => opt.MapFrom(src => src.UserDetail != null ? src.UserDetail.Experience : 0))
             .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => src.GymOwnerId != null ? src.GymOwnerId : null))
+            .ForMember(dest => dest.GymOwnerName, opt => opt.MapFrom(src => src.GymOwner != null ? src.GymOwner.GymName : null))
             .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive));
 
         CreateMap<ApplicationUser, GetGymPtsDetailForAdminResponseDto>()
@@ -77,7 +78,8 @@ public class AccountMappingProfile : Profile
             .ForMember(dest => dest.AvatarUrl, opt => opt.MapFrom(src => src.AvatarUrl))
             .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => src.GymOwnerId != null ? src.GymOwnerId : null))
             .ForMember(dest => dest.GoalTrainings, opt => opt.MapFrom(src => src.GoalTrainings.Select(x => x.Name).ToList()))
-            .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive));
+            .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive))
+            .ForMember(dest => dest.GymOwnerName, opt => opt.MapFrom(src => src.GymOwner != null ? src.GymOwner.GymName : null));
 
         CreateProjection<ApplicationUser, GetAllGymOwnerForAdminDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))


### PR DESCRIPTION
Added GymOwnerName to GetAllGymPtsForAdminResponseDto and GetGymPtsDetailForAdminResponseDto, replacing GymName in the latter. Introduced Id property to GetAllCustomersForAdminDto. Updated AccountMappingProfile to map new fields from related entities for improved admin data visibility.