### PR TITLE
#231 Add hot research subscription limit checks

### DIFF
--- a/FitBridge_API/Controllers/SubscriptionsController.cs
+++ b/FitBridge_API/Controllers/SubscriptionsController.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using FitBridge_Application.Dtos.Subscriptions;
 using FitBridge_Application.Features.Subscriptions.CancelSubscription;
+using FitBridge_Application.Features.Subscriptions.CheckMaximumHotResearchSubscription;
 
 namespace FitBridge_API.Controllers;
 
@@ -33,5 +34,12 @@ public class SubscriptionsController(IMediator mediator) : _BaseApiController
     {
         var result = await mediator.Send(new CancelSubscriptionCommand { userSubscriptionId = userSubscriptionId });
         return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Subscription cancelled successfully", result));
+    }
+
+    [HttpGet("check-hot-research-subscription")]
+    public async Task<IActionResult> CheckHotResearchSubscription()
+    {
+        var result = await mediator.Send(new CheckHotResearchSubscriptionQuery());
+        return Ok(new BaseResponse<CheckHotResearchDto>(StatusCodes.Status200OK.ToString(), "Maximum hot research subscription checked successfully", result));
     }
 }

--- a/FitBridge_Application/Commons/Constants/ProjectConstant.cs
+++ b/FitBridge_Application/Commons/Constants/ProjectConstant.cs
@@ -31,7 +31,7 @@ public static class ProjectConstant
         public const string GymSlotDuration = "MinimumGymSlotDuration";
         public const string CancelBookingBeforeHours = "CancelBookingBeforeHours";
         public const string ProfitDistributionDays = "ProfitDistributionDays";
-
+        public const string HotResearchSubscriptionLimit = "MaximumHotResearch";
     }
     public const int MaxRetries = 3;
     public static class EmailTypes

--- a/FitBridge_Application/Dtos/Subscriptions/CheckHotResearchDto.cs
+++ b/FitBridge_Application/Dtos/Subscriptions/CheckHotResearchDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Subscriptions;
+
+public class CheckHotResearchDto
+{
+    public bool IsHotResearchSubscriptionAvailable { get; set; }
+    public int NumOfCurrentHotResearchSubscription { get; set; }
+    public int MaxHotResearchSubscription { get; set; }
+}

--- a/FitBridge_Application/Features/Subscriptions/CheckMaximumHotResearchSubscription/CheckHotResearchSubscriptionQueryHandler.cs
+++ b/FitBridge_Application/Features/Subscriptions/CheckMaximumHotResearchSubscription/CheckHotResearchSubscriptionQueryHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using MediatR;
+using FitBridge_Application.Services;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Application.Commons.Constants;
+using FitBridge_Application.Dtos.Subscriptions;
+
+namespace FitBridge_Application.Features.Subscriptions.CheckMaximumHotResearchSubscription;
+
+public class CheckHotResearchSubscriptionQueryHandler(SubscriptionService subscriptionService, SystemConfigurationService systemConfigurationService) : IRequestHandler<CheckHotResearchSubscriptionQuery, CheckHotResearchDto>
+{
+    public async Task<CheckHotResearchDto> Handle(CheckHotResearchSubscriptionQuery request, CancellationToken cancellationToken)
+    {
+        var maxHotResearchSubscription = (int)await systemConfigurationService.GetSystemConfigurationAutoConvertDataTypeAsync(ProjectConstant.SystemConfigurationKeys.HotResearchSubscriptionLimit);
+        var numOfHotResearchSubscription = await subscriptionService.GetNumOfCurrentHotResearchSubscription();
+        if (numOfHotResearchSubscription >= maxHotResearchSubscription)
+        {
+            return new CheckHotResearchDto { IsHotResearchSubscriptionAvailable = false, NumOfCurrentHotResearchSubscription = numOfHotResearchSubscription, MaxHotResearchSubscription = maxHotResearchSubscription };
+        }
+        return new CheckHotResearchDto { IsHotResearchSubscriptionAvailable = true, NumOfCurrentHotResearchSubscription = numOfHotResearchSubscription, MaxHotResearchSubscription = maxHotResearchSubscription };
+    }
+
+}

--- a/FitBridge_Application/Features/Subscriptions/CheckMaximumHotResearchSubscription/CheckMaximumHotResearchSubscriptionQuery.cs
+++ b/FitBridge_Application/Features/Subscriptions/CheckMaximumHotResearchSubscription/CheckMaximumHotResearchSubscriptionQuery.cs
@@ -1,0 +1,8 @@
+using System;
+using MediatR;
+using FitBridge_Application.Dtos.Subscriptions;
+namespace FitBridge_Application.Features.Subscriptions.CheckMaximumHotResearchSubscription;
+
+public class CheckHotResearchSubscriptionQuery : IRequest<CheckHotResearchDto>
+{
+}

--- a/FitBridge_Application/Services/SubscriptionService.cs
+++ b/FitBridge_Application/Services/SubscriptionService.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Security.Cryptography.X509Certificates;
 using FitBridge_Application.Commons.Constants;
 using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Specifications.Subscriptions.GetHotResearchSubscription;
 using FitBridge_Domain.Entities.Identity;
 using FitBridge_Domain.Entities.ServicePackages;
 using FitBridge_Domain.Enums.SubscriptionPlans;
@@ -9,8 +11,8 @@ using FitBridge_Domain.Exceptions;
 
 namespace FitBridge_Application.Services;
 
-public class SubscriptionService(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService)
-    {
+public class SubscriptionService(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService, SystemConfigurationService _systemConfigurationService)
+{
     public async Task<bool> ExpireUserSubscription(Guid userSubscriptionId)
     {
         var userSubscription = await _unitOfWork.Repository<UserSubscription>().GetByIdAsync(userSubscriptionId, false, includes: new List<string> { "User", "SubscriptionPlansInformation", "SubscriptionPlansInformation.FeatureKey" });
@@ -28,10 +30,16 @@ public class SubscriptionService(IUnitOfWork _unitOfWork, IApplicationUserServic
         await _unitOfWork.CommitAsync();
         return true;
     }
-    
+
     public async Task RevokeHotResearchSubscriptionPlanBenefit(ApplicationUser user)
     {
         user.hotResearch = false;
         user.UpdatedAt = DateTime.UtcNow;
+    }
+
+    public async Task<int> GetNumOfCurrentHotResearchSubscription()
+    {
+        var numOfHotResearchSubscription = await _unitOfWork.Repository<UserSubscription>().CountAsync(new GetHotResearchSubscriptionSpecification());
+        return numOfHotResearchSubscription;
     }
 }

--- a/FitBridge_Application/Specifications/Subscriptions/GetHotResearchSubscription/GetHotResearchSubscriptionSpecification.cs
+++ b/FitBridge_Application/Specifications/Subscriptions/GetHotResearchSubscription/GetHotResearchSubscriptionSpecification.cs
@@ -1,0 +1,14 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.ServicePackages;
+using FitBridge_Application.Commons.Constants;
+using FitBridge_Domain.Enums.SubscriptionPlans;
+
+namespace FitBridge_Application.Specifications.Subscriptions.GetHotResearchSubscription;
+
+public class GetHotResearchSubscriptionSpecification : BaseSpecification<UserSubscription>
+{
+    public GetHotResearchSubscriptionSpecification() : base(x => x.SubscriptionPlansInformation.FeatureKey.FeatureName == ProjectConstant.FeatureKeyNames.HotResearch && x.Status == SubScriptionStatus.Active)
+    {
+    }
+}


### PR DESCRIPTION
Implemented logic to enforce maximum hot research subscription limit. Added DTO, query, handler, and specification for checking current hot research subscriptions. Updated payment link creation and subscription service to validate and count hot research subscriptions. Exposed new API endpoint for checking subscription availability.