### PR TITLE
#231 Add update endpoint for system configurations

### DIFF
--- a/FitBridge_API/Controllers/SystemConfigurationsController.cs
+++ b/FitBridge_API/Controllers/SystemConfigurationsController.cs
@@ -39,4 +39,13 @@ public class SystemConfigurationsController(IMediator _mediator) : _BaseApiContr
         var result = await _mediator.Send(new GetAllSystemConfigurationsQuery());
         return Ok(new BaseResponse<List<SystemConfigurationDto>>(StatusCodes.Status200OK.ToString(), "System configurations retrieved successfully", result));
     }
+
+    [HttpPut("{id}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> UpdateSystemConfiguration([FromRoute] Guid id, [FromBody] UpdateSystemConfigurationCommand command)
+    {
+        command.Id = id;
+        var result = await _mediator.Send(command);
+        return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "System configuration updated successfully", result));
+    }
 }

--- a/FitBridge_Application/Features/SystemConfigurations/UpdateSystemConfigurationCommand.cs
+++ b/FitBridge_Application/Features/SystemConfigurations/UpdateSystemConfigurationCommand.cs
@@ -1,0 +1,14 @@
+using System;
+using MediatR;
+using System.Text.Json.Serialization;
+using FitBridge_Domain.Enums.SystemConfigs;
+
+namespace FitBridge_Application.Features.SystemConfigurations;
+
+public class UpdateSystemConfigurationCommand : IRequest<bool>
+{
+    [JsonIgnore]
+    public Guid Id { get; set; }
+    public string? Value { get; set; }
+    public string? Description { get; set; }
+}

--- a/FitBridge_Application/Features/SystemConfigurations/UpdateSystemConfigurationCommandHandler.cs
+++ b/FitBridge_Application/Features/SystemConfigurations/UpdateSystemConfigurationCommandHandler.cs
@@ -1,0 +1,25 @@
+using System;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Systems;
+using FitBridge_Domain.Exceptions;
+using MediatR;
+
+namespace FitBridge_Application.Features.SystemConfigurations;
+
+public class UpdateSystemConfigurationCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<UpdateSystemConfigurationCommand, bool>
+{
+    public async Task<bool> Handle(UpdateSystemConfigurationCommand request, CancellationToken cancellationToken)
+    {
+        var systemConfiguration = await _unitOfWork.Repository<SystemConfiguration>().GetByIdAsync(request.Id);
+        if (systemConfiguration == null)
+        {
+            throw new NotFoundException(nameof(SystemConfiguration));
+        }
+        systemConfiguration.Value = request.Value ?? systemConfiguration.Value;
+        systemConfiguration.Description = request.Description ?? systemConfiguration.Description;
+        _unitOfWork.Repository<SystemConfiguration>().Update(systemConfiguration);
+        await _unitOfWork.CommitAsync();
+        return true;
+    }
+
+}


### PR DESCRIPTION
Introduced an HTTP PUT endpoint in SystemConfigurationsController to allow admins to update system configurations. Added UpdateSystemConfigurationCommand and its handler to process update requests and persist changes.