### PR TITLE
Improve notification category mapping and DTO

### DIFF
--- a/FitBridge_Application/Dtos/Notifications/NotificationDto.cs
+++ b/FitBridge_Application/Dtos/Notifications/NotificationDto.cs
@@ -15,10 +15,14 @@ namespace FitBridge_Application.Dtos.Notifications
 
         public bool IsRead { get; set; }
 
-        public string NotificationCategory { get; set; } = notificationCategory;
+        public string? NotificationCategory { get; set; } = notificationCategory;
 
         public NotificationTypes NotificationType { get; set; }
 
         public string? AdditionalPayload { get; set; } = additionalPayload;
+
+        public NotificationDto() : this("", "")
+        {
+        }
     }
 }

--- a/FitBridge_Application/MappingProfiles/NotificationMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/NotificationMappingProfile.cs
@@ -11,6 +11,7 @@ namespace FitBridge_Application.MappingProfiles
         {
             CreateMap<Notification, NotificationDto>()
                 .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => new DateTimeOffset(src.CreatedAt).ToUnixTimeMilliseconds()))
+                .ForMember(dest => dest.NotificationCategory, opt => opt.MapFrom(src => src.Template.ContentType.ToString()))
                 .ForMember(dest => dest.IsRead, opt => opt.MapFrom(src => src.ReadAt.HasValue));
         }
     }

--- a/FitBridge_Application/Specifications/Notifications/GetNotificationsByUserId/GetNotificationsByUserIdSpecification.cs
+++ b/FitBridge_Application/Specifications/Notifications/GetNotificationsByUserId/GetNotificationsByUserIdSpecification.cs
@@ -10,6 +10,7 @@ namespace FitBridge_Application.Specifications.Notifications.GetNotificationsByU
             bool onlyUnread = false) : base(x =>
             x.IsEnabled && x.UserId == userId && ((onlyUnread && x.ReadAt == null) || !onlyUnread))
         {
+            AddInclude(x => x.Template);
             if (parameters != null && parameters.DoApplyPaging)
             {
                 AddPaging(parameters.Size * (parameters.Page - 1), parameters.Size);


### PR DESCRIPTION
Changed NotificationDto.NotificationCategory to nullable and updated its default value. Added mapping for NotificationCategory from Notification.Template.ContentType. Included Template in GetNotificationsByUserIdSpecification to support category mapping.
