### PR TITLE
Filter coupon overlap by creator and update FirebaseAdmin

### DIFF
--- a/FitBridge_Application/Features/Coupons/CreateCoupon/CreateCouponCommandHandler.cs
+++ b/FitBridge_Application/Features/Coupons/CreateCoupon/CreateCouponCommandHandler.cs
@@ -46,7 +46,7 @@ namespace FitBridge_Application.Features.Coupons.CreateCoupon
                 Id = Guid.NewGuid()
             };
 
-            var overlappedCoupons = await GetOverlappedCoupons(newCoupon.StartDate);
+            var overlappedCoupons = await GetOverlappedCoupons(newCoupon.StartDate, creatorId);
             if (overlappedCoupons.Count > 0)
             {
                 throw new CouponOverlapException(overlappedCoupons[0].CouponCode);
@@ -77,9 +77,9 @@ namespace FitBridge_Application.Features.Coupons.CreateCoupon
             };
         }
 
-        private async Task<IReadOnlyList<Coupon>> GetOverlappedCoupons(DateOnly expirationDate)
+        private async Task<IReadOnlyList<Coupon>> GetOverlappedCoupons(DateOnly expirationDate, Guid creatorId)
         {
-            var spec = new GetOverlapCouponsSpec(expirationDate);
+            var spec = new GetOverlapCouponsSpec(expirationDate, creatorId);
             var overlapCoupons = await unitOfWork.Repository<Coupon>().GetAllWithSpecificationAsync(spec);
 
             return overlapCoupons;

--- a/FitBridge_Application/Specifications/Coupons/GetOverlapCoupons/GetOverlapCouponsSpec.cs
+++ b/FitBridge_Application/Specifications/Coupons/GetOverlapCoupons/GetOverlapCouponsSpec.cs
@@ -5,8 +5,8 @@ namespace FitBridge_Application.Specifications.Coupons.GetOverlapCoupons
 {
     public class GetOverlapCouponsSpec : BaseSpecification<Coupon>
     {
-        public GetOverlapCouponsSpec(DateOnly startDate) : base(x =>
-            x.IsActive && x.IsEnabled && x.NumberOfUsedCoupon != 0
+        public GetOverlapCouponsSpec(DateOnly startDate, Guid creatorId) : base(x =>
+            x.IsActive && x.IsEnabled && x.NumberOfUsedCoupon != 0 && x.CreatorId == creatorId
             && x.ExpirationDate >= startDate)
         {
         }

--- a/FitBridge_Infrastructure/FitBridge_Infrastructure.csproj
+++ b/FitBridge_Infrastructure/FitBridge_Infrastructure.csproj
@@ -28,7 +28,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
 		<PackageReference Include="NRedisStack" Version="1.1.1" />
 		<PackageReference Include="payOS" Version="1.0.9" />
-		<PackageReference Include="FirebaseAdmin" Version="3.2.0" />
+		<PackageReference Include="FirebaseAdmin" Version="3.4.0" />
 		<PackageReference Include="Quartz" Version="3.15.0" />
 		<PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.15.0" />
 		<PackageReference Include="Quartz.Extensions.Hosting" Version="3.15.0" />


### PR DESCRIPTION
Added creatorId filtering to coupon overlap checks to ensure overlaps are only detected for the same creator. Updated FirebaseAdmin package from version 3.2.0 to 3.4.0 in infrastructure project.
