### PR TITLE
Pass userId to GetMessagesSpec and update UpdatedAt default

### DIFF
--- a/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
@@ -13,11 +13,15 @@ namespace FitBridge_Application.Features.Messaging.GetMessages
 {
     internal class GetMessagesQueryHandler(
         IUnitOfWork unitOfWork,
+        IUserUtil userUtil,
+        IHttpContextAccessor httpContextAccessor,
         MessagingService messagingService) : IRequestHandler<GetMessagesQuery, IEnumerable<GetMessagesDto>>
     {
         public async Task<IEnumerable<GetMessagesDto>> Handle(GetMessagesQuery request, CancellationToken cancellationToken)
         {
+            var userId = userUtil.GetAccountId(httpContextAccessor.HttpContext);
             var spec = new GetMessagesSpec(request.ConversationId,
+                userId: userId,
                 parameters: request.Params,
                 includeOwnMessageStatus: true,
                 includeBookingRequest: true,

--- a/FitBridge_Infrastructure/Configurations/MessageConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/MessageConfiguration.cs
@@ -11,7 +11,7 @@ public class MessageConfiguration : IEntityTypeConfiguration<Message>
     public void Configure(EntityTypeBuilder<Message> builder)
     {
         builder.ToTable("Messages");
-        
+
         // Property configurations
         builder.Property(e => e.Content).IsRequired(true);
         builder.Property(e => e.MessageType)
@@ -32,7 +32,7 @@ public class MessageConfiguration : IEntityTypeConfiguration<Message>
         builder.Property(e => e.ReplyToMessageId).IsRequired(false);
         builder.Property(e => e.BookingRequestId).IsRequired(false);
         builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
-        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NULL");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);
 
         // Relationship configurations


### PR DESCRIPTION
GetMessagesQueryHandler now retrieves the userId using IUserUtil and IHttpContextAccessor and passes it to GetMessagesSpec. In MessageConfiguration, the default value for UpdatedAt is changed from NOW() to NULL.
