### PR TITLE
#107 Replace InvalidDataException with DataValidationFailedException

### DIFF
--- a/FitBridge_Application/Features/Categories/CreateCategory/CreateCategoryCommandHandler.cs
+++ b/FitBridge_Application/Features/Categories/CreateCategory/CreateCategoryCommandHandler.cs
@@ -2,6 +2,7 @@ using FitBridge_Application.Dtos.Categories;
 using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Application.Specifications.Categories.GetCategoryByName;
 using FitBridge_Domain.Entities.Ecommerce;
+using FitBridge_Domain.Exceptions;
 using MediatR;
 
 namespace FitBridge_Application.Features.Categories.CreateCategory
@@ -14,10 +15,10 @@ namespace FitBridge_Application.Features.Categories.CreateCategory
             var spec = new GetCategoryByNameSpec(request.Name);
             var category = await unitOfWork.Repository<Category>()
                 .GetBySpecificationAsync(spec);
-            
+
             if (category != null)
             {
-                throw new InvalidDataException($"Category with name '{request.Name}' already exists.");
+                throw new DataValidationFailedException($"Category with name '{request.Name}' already exists.");
             }
 
             var newCategory = new Category

--- a/FitBridge_Application/Features/Categories/CreateSubCategory/CreateSubCategoryCommandHandler.cs
+++ b/FitBridge_Application/Features/Categories/CreateSubCategory/CreateSubCategoryCommandHandler.cs
@@ -23,7 +23,7 @@ namespace FitBridge_Application.Features.Categories.CreateSubCategory
             
             if (subCategory != null)
             {
-                throw new InvalidDataException($"SubCategory with name '{request.Name}' already exists in this category.");
+                throw new DataValidationFailedException($"SubCategory with name '{request.Name}' already exists in this category.");
             }
 
             var newSubCategory = new SubCategory

--- a/FitBridge_Application/Features/Categories/UpdateCategory/UpdateCategoryCommandHandler.cs
+++ b/FitBridge_Application/Features/Categories/UpdateCategory/UpdateCategoryCommandHandler.cs
@@ -21,7 +21,7 @@ namespace FitBridge_Application.Features.Categories.UpdateCategory
             
             if (existingCategory != null && existingCategory.Id != request.Id)
             {
-                throw new InvalidDataException($"Category with name '{request.Name}' already exists.");
+                throw new DataValidationFailedException($"Category with name '{request.Name}' already exists.");
             }
 
             category.Name = request.Name;

--- a/FitBridge_Application/Features/Categories/UpdateSubCategory/UpdateSubCategoryCommandHandler.cs
+++ b/FitBridge_Application/Features/Categories/UpdateSubCategory/UpdateSubCategoryCommandHandler.cs
@@ -25,7 +25,7 @@ namespace FitBridge_Application.Features.Categories.UpdateSubCategory
 
             if (existingSubCategory != null && existingSubCategory.Id != request.Id)
             {
-                throw new InvalidDataException($"SubCategory with name '{request.Name}' already exists in this category.");
+                throw new DataValidationFailedException($"SubCategory with name '{request.Name}' already exists in this category.");
             }
 
             subCategory.Name = request.Name;

--- a/FitBridge_Application/Features/Flavours/CreateFlavour/CreateFlavourCommandHandler.cs
+++ b/FitBridge_Application/Features/Flavours/CreateFlavour/CreateFlavourCommandHandler.cs
@@ -3,6 +3,7 @@ using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Application.Specifications.Flavours.GetAllFlavours;
 using FitBridge_Application.Specifications.Flavours.GetFlavourByName;
 using FitBridge_Domain.Entities.Ecommerce;
+using FitBridge_Domain.Exceptions;
 using MediatR;
 
 namespace FitBridge_Application.Features.Flavours.CreateFlavour
@@ -17,7 +18,7 @@ namespace FitBridge_Application.Features.Flavours.CreateFlavour
                 .GetBySpecificationAsync(spec);
             if (flavour != null)
             {
-                throw new InvalidDataException($"Flavour with name '{request.Name}' already exists.");
+                throw new DataValidationFailedException($"Flavour with name '{request.Name}' already exists.");
             }
 
             var newFlavour = new Flavour

--- a/FitBridge_Application/Features/Flavours/UpdateFlavour/UpdateFlavourCommandHandler.cs
+++ b/FitBridge_Application/Features/Flavours/UpdateFlavour/UpdateFlavourCommandHandler.cs
@@ -21,7 +21,7 @@ namespace FitBridge_Application.Features.Flavours.UpdateFlavour
 
             if (existingFlavour != null && existingFlavour.Id != request.Id)
             {
-                throw new InvalidDataException($"Flavour with name '{request.Name}' already exists.");
+                throw new DataValidationFailedException($"Flavour with name '{request.Name}' already exists.");
             }
 
             flavour.Name = request.Name;

--- a/FitBridge_Application/Features/Messaging/CreateConversation/CreateConversationCommandHandler.cs
+++ b/FitBridge_Application/Features/Messaging/CreateConversation/CreateConversationCommandHandler.cs
@@ -27,7 +27,7 @@ namespace FitBridge_Application.Features.Messaging.CreateConversation
             var now = DateTime.UtcNow;
             if (request.Members.Count > 2 && !request.IsGroup)
             {
-                throw new InvalidDataException("A conversation with more than 2 members must be a group.");
+                throw new DataValidationFailedException("A conversation with more than 2 members must be a group.");
             }
 
             var memberIds = request.Members.Select(m => m.MemberId).ToList();

--- a/FitBridge_Application/Features/Messaging/DeleteMessage/DeleteMessageCommandHandler.cs
+++ b/FitBridge_Application/Features/Messaging/DeleteMessage/DeleteMessageCommandHandler.cs
@@ -27,15 +27,15 @@ namespace FitBridge_Application.Features.Messaging.DeleteMessage
 
             var existingMessage = await unitOfWork.Repository<Message>().GetByIdAsync(request.MessageId, includes: [nameof(Message.Conversation)])
                 ?? throw new NotFoundException(nameof(Message));
-            
+
             // Get the user's ConversationMember record to compare with SenderId
             var memberSpec = new GetConversationMembersSpec(existingMessage.ConversationId, userId);
             var senderMember = await unitOfWork.Repository<ConversationMember>().GetBySpecificationAsync(memberSpec)
                 ?? throw new NotFoundException("User is not a member of this conversation");
-            
+
             if (existingMessage.SenderId != senderMember.Id)
             {
-                throw new InvalidDataException("Sender not match with database");
+                throw new DataValidationFailedException("Sender not match with database");
             }
 
             existingMessage.DeletedAt = now;

--- a/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
@@ -2,6 +2,7 @@
 using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Application.Interfaces.Utils;
 using FitBridge_Application.Services;
+using FitBridge_Application.Specifications.Messaging.GetConversationMembers;
 using FitBridge_Application.Specifications.Messaging.GetMessages;
 using FitBridge_Domain.Entities.MessageAndReview;
 using FitBridge_Domain.Exceptions;
@@ -20,8 +21,11 @@ namespace FitBridge_Application.Features.Messaging.GetMessages
         public async Task<IEnumerable<GetMessagesDto>> Handle(GetMessagesQuery request, CancellationToken cancellationToken)
         {
             var userId = userUtil.GetAccountId(httpContextAccessor.HttpContext);
+            var memberSpec = new GetConversationMembersSpec(request.ConversationId, userId);
+            var convoMember = await unitOfWork.Repository<ConversationMember>().GetBySpecificationAsync(memberSpec)
+                ?? throw new NotFoundException("User is not a member of this conversation");
             var spec = new GetMessagesSpec(request.ConversationId,
-                userId: userId,
+                userId: convoMember.Id,
                 parameters: request.Params,
                 includeOwnMessageStatus: true,
                 includeBookingRequest: true,

--- a/FitBridge_Application/Features/Messaging/ReactMessage/ReactMessageCommandHandler.cs
+++ b/FitBridge_Application/Features/Messaging/ReactMessage/ReactMessageCommandHandler.cs
@@ -26,7 +26,8 @@ namespace FitBridge_Application.Features.Messaging.ReactMessage
             var senderId = userUtil.GetAccountId(httpContextAccessor.HttpContext)
                      ?? throw new NotFoundException(nameof(ApplicationUser));
 
-            var message = await unitOfWork.Repository<Message>().GetByIdAsync(senderId, includes: [nameof(Message.Conversation)]);
+            var message = await unitOfWork.Repository<Message>().GetByIdAsync(
+                request.MessageId, includes: [nameof(Message.Conversation)]);
 
             if (message == null)
             {
@@ -39,7 +40,7 @@ namespace FitBridge_Application.Features.Messaging.ReactMessage
 
             if (!isMember)
             {
-                throw new InvalidDataException("Not a member of the conversation");
+                throw new DataValidationFailedException("Not a member of the conversation");
             }
 
             if (request.RemoveReaction)

--- a/FitBridge_Application/Features/Messaging/ReadMessages/ReadMessagesCommandHandler.cs
+++ b/FitBridge_Application/Features/Messaging/ReadMessages/ReadMessagesCommandHandler.cs
@@ -41,7 +41,7 @@ namespace FitBridge_Application.Features.Messaging.ReadMessages
 
             if (messages.Count != messageIds.Count)
             {
-                throw new InvalidDataException("Some messages not found or don't belong to this conversation.");
+                throw new DataValidationFailedException("Some messages not found or don't belong to this conversation.");
             }
 
             var now = DateTime.UtcNow;

--- a/FitBridge_Application/Features/Messaging/SendMessage/SendMessageCommandHandler.cs
+++ b/FitBridge_Application/Features/Messaging/SendMessage/SendMessageCommandHandler.cs
@@ -42,7 +42,7 @@ namespace FitBridge_Application.Features.Messaging.SendMessage
 
             var spec = new GetConversationMembersSpec(request.ConversationId);
             var conversationMembers = await unitOfWork.Repository<ConversationMember>().GetAllWithSpecificationAsync(spec);
-            
+
             // Get the sender's ConversationMember record
             var senderMember = conversationMembers.FirstOrDefault(x => x.UserId == senderId)
                 ?? throw new NotFoundException("Sender is not a member of this conversation");
@@ -69,11 +69,11 @@ namespace FitBridge_Application.Features.Messaging.SendMessage
             {
                 if (request.CreateBookingRequest == null)
                 {
-                    throw new InvalidDataException("CreateBookingRequest data must be provided for BookingRequest media type");
+                    throw new DataValidationFailedException("CreateBookingRequest data must be provided for BookingRequest media type");
                 }
                 if (request.CustomerPurchasedId == null)
                 {
-                    throw new InvalidDataException("CustomerPurchasedId must be provided for BookingRequest media type");
+                    throw new DataValidationFailedException("CustomerPurchasedId must be provided for BookingRequest media type");
                 }
                 newSystemMessage = new Message
                 {

--- a/FitBridge_Application/Features/Weights/CreateWeight/CreateWeightCommandHandler.cs
+++ b/FitBridge_Application/Features/Weights/CreateWeight/CreateWeightCommandHandler.cs
@@ -2,6 +2,7 @@ using FitBridge_Application.Dtos.Weights;
 using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Application.Specifications.Weights.GetWeightByValueAndUnit;
 using FitBridge_Domain.Entities.Ecommerce;
+using FitBridge_Domain.Exceptions;
 using MediatR;
 
 namespace FitBridge_Application.Features.Weights.CreateWeight
@@ -17,7 +18,7 @@ namespace FitBridge_Application.Features.Weights.CreateWeight
 
             if (weight != null)
             {
-                throw new InvalidDataException($"Weight with value '{request.Value}' and unit '{request.Unit}' already exists.");
+                throw new DataValidationFailedException($"Weight with value '{request.Value}' and unit '{request.Unit}' already exists.");
             }
 
             var newWeight = new Weight

--- a/FitBridge_Application/Features/Weights/UpdateWeight/UpdateWeightCommandHandler.cs
+++ b/FitBridge_Application/Features/Weights/UpdateWeight/UpdateWeightCommandHandler.cs
@@ -21,7 +21,7 @@ namespace FitBridge_Application.Features.Weights.UpdateWeight
 
             if (existingWeight != null && existingWeight.Id != request.Id)
             {
-                throw new InvalidDataException($"Weight with value '{request.Value}' and unit '{request.Unit}' already exists.");
+                throw new DataValidationFailedException($"Weight with value '{request.Value}' and unit '{request.Unit}' already exists.");
             }
 
             weight.Value = request.Value;


### PR DESCRIPTION
Updated command handlers to throw DataValidationFailedException instead of InvalidDataException for validation errors across categories, flavours, messaging, and weights features. Also fixed a bug in ReactMessageCommandHandler to use the correct message ID and improved sender validation in UpdateMessageCommandHandler.
