### PR TITLE
#107 Update conversation and message member role handling

### DIFF
--- a/FitBridge_Application/Features/Messaging/GetConversations/GetConversationsQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetConversations/GetConversationsQueryHandler.cs
@@ -1,19 +1,22 @@
 ﻿using FitBridge_Application.Dtos;
 using FitBridge_Application.Dtos.Messaging;
 using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Interfaces.Services;
 using FitBridge_Application.Interfaces.Utils;
 using FitBridge_Application.Specifications.Messaging.GetConversations;
 using FitBridge_Domain.Entities.Identity;
 using FitBridge_Domain.Entities.MessageAndReview;
 using FitBridge_Domain.Exceptions;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 
 namespace FitBridge_Application.Features.Messaging.GetConversations;
 
 internal class GetConversationsQueryHandler(
     IUnitOfWork unitOfWork,
     IUserUtil userUtil,
-    Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor) : IRequestHandler<GetConversationsQuery, PagingResultDto<GetConversationsDto>>
+    IApplicationUserService applicationUserService,
+    IHttpContextAccessor httpContextAccessor) : IRequestHandler<GetConversationsQuery, PagingResultDto<GetConversationsDto>>
 {
     public async Task<PagingResultDto<GetConversationsDto>> Handle(GetConversationsQuery request, CancellationToken cancellationToken)
     {
@@ -27,30 +30,45 @@ internal class GetConversationsQueryHandler(
             .GetAllWithSpecificationAsync(spec, asNoTracking: true);
         var totalCount = await unitOfWork.Repository<Conversation>().CountAsync(spec);
 
-        var dtos = conversations.Select(x => new GetConversationsDto
-        {
-            Id = x.Id,
-            IsGroup = x.IsGroup,
-            Title = x.ConversationMembers.First(cm => cm.UserId == userId).CustomTitle,
-            UpdatedAt = x.UpdatedAt,
-            LastMessageContent = x.LastMessageContent,
-            LastMessageType = x.LastMessageType.ToString(),
-            LastMessageMediaType = x.LastMessageMediaType.ToString(),
-            LastMessageSenderName = x.LastMessageSenderName,
-            LastMessageSenderId = x.LastMessageSenderId,
-            IsRead = !x.Messages.Any(m => m.Id == x.LastMessageId)
-                || x.Messages.FirstOrDefault(m => m.Id == x.LastMessageId)?
-                .MessageStatuses.FirstOrDefault(ms => ms.UserId == userId)?.ReadAt != null,
-            ConversationImg = x.ConversationMembers.First(cm => cm.UserId == userId).ConversationImage,
-            Members = x.ConversationMembers.Select(cm => new GetConversationMembersDto
-            {
-                UserId = cm.UserId,
-                Username = cm.User.UserName ?? string.Empty,
-                ImgUrl = cm.User.AvatarUrl ?? string.Empty,
-                Role = userRole
-            })
-        }).OrderByDescending(x => x.UpdatedAt).ToList();
+        var dtos = new List<GetConversationsDto>();
 
-        return new PagingResultDto<GetConversationsDto>(totalCount, dtos);
+        foreach (var x in conversations)
+        {
+            var members = new List<GetConversationMembersDto>();
+
+            foreach (var cm in x.ConversationMembers)
+            {
+                var memberRole = await applicationUserService.GetUserRoleAsync(cm.User);
+                members.Add(new GetConversationMembersDto
+                {
+                    UserId = cm.UserId,
+                    Username = cm.User.UserName ?? string.Empty,
+                    ImgUrl = cm.User.AvatarUrl ?? string.Empty,
+                    Role = memberRole
+                });
+            }
+
+            dtos.Add(new GetConversationsDto
+            {
+                Id = x.Id,
+                IsGroup = x.IsGroup,
+                Title = x.ConversationMembers.First(cm => cm.UserId == userId).CustomTitle,
+                UpdatedAt = x.UpdatedAt,
+                LastMessageContent = x.LastMessageContent,
+                LastMessageType = x.LastMessageType.ToString(),
+                LastMessageMediaType = x.LastMessageMediaType.ToString(),
+                LastMessageSenderName = x.LastMessageSenderName,
+                LastMessageSenderId = x.LastMessageSenderId,
+                IsRead = !x.Messages.Any(m => m.Id == x.LastMessageId)
+                    || x.Messages.FirstOrDefault(m => m.Id == x.LastMessageId)?
+                    .MessageStatuses.FirstOrDefault(ms => ms.UserId == userId)?.ReadAt != null,
+                ConversationImg = x.ConversationMembers.First(cm => cm.UserId == userId).ConversationImage,
+                Members = members
+            });
+        }
+
+        var orderedDtos = dtos.OrderByDescending(x => x.UpdatedAt).ToList();
+
+        return new PagingResultDto<GetConversationsDto>(totalCount, orderedDtos);
     }
 }

--- a/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
@@ -53,7 +53,7 @@ namespace FitBridge_Application.Features.Messaging.GetMessages
                 ReplyToMessageMediaType = x.ReplyToMessage?.MediaType.ToString(),
                 SenderId = x.Sender.UserId,
                 Reaction = x.Reaction ?? string.Empty,
-                SenderName = x.Sender?.User.UserName,
+                SenderName = x.Sender?.User.FullName,
                 SenderAvatarUrl = x.Sender?.User.AvatarUrl,
                 BookingRequest = x.BookingRequest != null ? MapBookingRequestDto(x.BookingRequest) : null
             });

--- a/FitBridge_Application/Features/Messaging/GetMessagesInRange/GetMessagesInRangeQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetMessagesInRange/GetMessagesInRangeQueryHandler.cs
@@ -66,7 +66,7 @@ namespace FitBridge_Application.Features.Messaging.GetMessagesInRange
                 ReplyToMessageMediaType = x.ReplyToMessage?.MediaType.ToString(),
                 SenderId = x.Sender.Id,
                 Reaction = x.Reaction ?? string.Empty,
-                SenderName = x.Sender?.User.UserName,
+                SenderName = x.Sender?.User.FullName,
                 SenderAvatarUrl = x.MessageType != MessageType.System
                     ? x.Sender?.User.AvatarUrl
                     : null,


### PR DESCRIPTION
Refactored GetConversationsQueryHandler to retrieve user roles via IApplicationUserService and populate member roles in conversation DTOs. Updated GetMessagesQueryHandler and GetMessagesInRangeQueryHandler to use FullName instead of UserName for sender display.
