### PR TITLE
Fix null reference for SenderId in message handlers

### DIFF
--- a/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetMessages/GetMessagesQueryHandler.cs
@@ -51,7 +51,7 @@ namespace FitBridge_Application.Features.Messaging.GetMessages
                 ReplyToMessageId = x.ReplyToMessageId,
                 ReplyToMessageContent = x.ReplyToMessage?.Content,
                 ReplyToMessageMediaType = x.ReplyToMessage?.MediaType.ToString(),
-                SenderId = x.Sender.UserId,
+                SenderId = x.Sender?.UserId,
                 Reaction = x.Reaction ?? string.Empty,
                 SenderName = x.Sender?.User.FullName,
                 SenderAvatarUrl = x.Sender?.User.AvatarUrl,

--- a/FitBridge_Application/Features/Messaging/GetMessagesInRange/GetMessagesInRangeQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetMessagesInRange/GetMessagesInRangeQueryHandler.cs
@@ -64,7 +64,7 @@ namespace FitBridge_Application.Features.Messaging.GetMessagesInRange
                 ReplyToMessageId = x.ReplyToMessageId,
                 ReplyToMessageContent = x.ReplyToMessage?.Content,
                 ReplyToMessageMediaType = x.ReplyToMessage?.MediaType.ToString(),
-                SenderId = x.Sender.Id,
+                SenderId = x.Sender?.Id,
                 Reaction = x.Reaction ?? string.Empty,
                 SenderName = x.Sender?.User.FullName,
                 SenderAvatarUrl = x.MessageType != MessageType.System


### PR DESCRIPTION
Updated SenderId assignments in GetMessagesQueryHandler and GetMessagesInRangeQueryHandler to use null-conditional access, preventing possible null reference exceptions when Sender is null.
