### PR TITLE
#245 Add shop default address support and admin address queries

### DIFF
--- a/FitBridge_API/Controllers/AddressesController.cs
+++ b/FitBridge_API/Controllers/AddressesController.cs
@@ -8,6 +8,8 @@ using FitBridge_Application.Features.Addresses.GetAllCustomerAddress;
 using FitBridge_Application.Features.Addresses.GetAddressById;
 using FitBridge_Application.Features.Addresses.DeleteAddress;
 using FitBridge_Application.Features.Addresses.UpdateAddress;
+using FitBridge_Application.Features.Addresses.GetAllShopAddress;
+using FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
 
 namespace FitBridge_API.Controllers;
 
@@ -38,17 +40,34 @@ public class AddressesController(IMediator _mediator) : _BaseApiController
     }
 
     [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete([FromRoute] string id)
+    public async Task<IActionResult> DeleteAddress([FromRoute] string id)
     {
         var result = await _mediator.Send(new DeleteAddressCommand(Guid.Parse(id)));
         return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Address deleted successfully", result));
     }
 
+    /// <summary>
+    /// Update an address, pass IsShopDefaultAddress to switch default address to this address, cannot be false
+    /// </summary>
+    /// <param name="IsShopDefaultAddress">True to switch default address to this address, cannot be false</param>
+    /// <returns></returns>
     [HttpPut("{id}")]
-    public async Task<IActionResult> Update([FromRoute] string id, [FromBody] UpdateAddressCommand command)
+    public async Task<IActionResult> UpdateAddress([FromRoute] string id, [FromBody] UpdateAddressCommand command)
     {
         command.Id = Guid.Parse(id);
         var result = await _mediator.Send(command);
         return Ok(new BaseResponse<AddressResponseDto>(StatusCodes.Status200OK.ToString(), "Address updated successfully", result));
+    }
+
+    /// <summary>
+    /// Get all shop addresses of all admin accounts
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("admin/shop-address")]
+    public async Task<IActionResult> GetAllShopAddress([FromQuery] GetAllShopAddressParams parameters)
+    {
+        var result = await _mediator.Send(new GetAllShopAddressQuery(parameters));
+        var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
+        return Ok(new BaseResponse<Pagination<AddressResponseDto>>(StatusCodes.Status200OK.ToString(), "Shop address retrieved successfully", pagination));
     }
 }

--- a/FitBridge_Application/Dtos/Addresses/AddressResponseDto.cs
+++ b/FitBridge_Application/Dtos/Addresses/AddressResponseDto.cs
@@ -17,4 +17,5 @@ public class AddressResponseDto
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
     public string? GoogleMapAddressString { get; set; }
+    public bool IsShopDefaultAddress { get; set; }
 }

--- a/FitBridge_Application/Features/Addresses/CreateAddress/CreateAddressCommand.cs
+++ b/FitBridge_Application/Features/Addresses/CreateAddress/CreateAddressCommand.cs
@@ -17,4 +17,5 @@ public class CreateAddressCommand : IRequest<string>
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
     public string? GoogleMapAddressString { get; set; }
+    public bool? IsShopDefaultAddress { get; set; }
 }

--- a/FitBridge_Application/Features/Addresses/CreateAddress/CreateAddressCommandHandler.cs
+++ b/FitBridge_Application/Features/Addresses/CreateAddress/CreateAddressCommandHandler.cs
@@ -6,10 +6,13 @@ using AutoMapper;
 using FitBridge_Application.Interfaces.Utils;
 using Microsoft.AspNetCore.Http;
 using FitBridge_Domain.Exceptions;
+using FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
+using FitBridge_Application.Commons.Constants;
+using FitBridge_Application.Interfaces.Services;
 
 namespace FitBridge_Application.Features.Addresses.CreateAddress;
 
-public class CreateAddressCommandHandler(IUnitOfWork unitOfWork, IMapper mapper, IUserUtil userUtil, IHttpContextAccessor httpContextAccessor) : IRequestHandler<CreateAddressCommand, string>
+public class CreateAddressCommandHandler(IUnitOfWork unitOfWork, IMapper mapper, IUserUtil userUtil, IHttpContextAccessor httpContextAccessor, IApplicationUserService applicationUserService) : IRequestHandler<CreateAddressCommand, string>
 {
     public async Task<string> Handle(CreateAddressCommand request, CancellationToken cancellationToken)
     {
@@ -18,10 +21,30 @@ public class CreateAddressCommandHandler(IUnitOfWork unitOfWork, IMapper mapper,
         {
             throw new NotFoundException("Customer not found");
         }
+
         var address = mapper.Map<CreateAddressCommand, Address>(request);
         address.CustomerId = customerId.Value;
+        if (request.IsShopDefaultAddress.HasValue && request.IsShopDefaultAddress == true)
+        {
+            await SwitchShopDefaultAddress();
+            address.IsShopDefaultAddress = true;
+        } else {
+            address.IsShopDefaultAddress = false;
+        }
         unitOfWork.Repository<Address>().Insert(address);
         await unitOfWork.CommitAsync();
         return address.Id.ToString();
+    }
+    
+    public async Task SwitchShopDefaultAddress()
+    {
+        var adminAccounts = await applicationUserService.GetUsersByRoleAsync(ProjectConstant.UserRoles.Admin);
+        var adminAccountIds = adminAccounts.Select(x => x.Id).ToList();
+        var addresses = await unitOfWork.Repository<Address>().GetAllWithSpecificationAsync(new GetAllShopAddressSpec(adminAccountIds));
+        foreach(var address in addresses)
+        {
+            address.IsShopDefaultAddress = false;
+            unitOfWork.Repository<Address>().Update(address);
+        }
     }
 }

--- a/FitBridge_Application/Features/Addresses/DeleteAddress/DeleteAddressCommandHandler.cs
+++ b/FitBridge_Application/Features/Addresses/DeleteAddress/DeleteAddressCommandHandler.cs
@@ -15,6 +15,10 @@ public class DeleteAddressCommandHandler(IUnitOfWork unitOfWork) : IRequestHandl
         {
             throw new NotFoundException("Address not found");
         }
+        if(address.IsShopDefaultAddress)
+        {
+            throw new BusinessException("Shop default address cannot be deleted, please choose another address as shop default address for auto switch");
+        }
         unitOfWork.Repository<Address>().Delete(address);
         await unitOfWork.CommitAsync();
         return true;

--- a/FitBridge_Application/Features/Addresses/GetAllShopAddress/GetAllShopAddressQuery.cs
+++ b/FitBridge_Application/Features/Addresses/GetAllShopAddress/GetAllShopAddressQuery.cs
@@ -1,0 +1,11 @@
+using System;
+using FitBridge_Application.Dtos.Addresses;
+using FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
+using MediatR;
+using FitBridge_Application.Dtos;
+namespace FitBridge_Application.Features.Addresses.GetAllShopAddress;
+
+public class GetAllShopAddressQuery(GetAllShopAddressParams parameters) : IRequest<PagingResultDto<AddressResponseDto>>
+{
+    public GetAllShopAddressParams Params { get; set; } = parameters;
+}

--- a/FitBridge_Application/Features/Addresses/GetAllShopAddress/GetAllShopAddressQueryHandler.cs
+++ b/FitBridge_Application/Features/Addresses/GetAllShopAddress/GetAllShopAddressQueryHandler.cs
@@ -1,0 +1,24 @@
+using System;
+using FitBridge_Application.Dtos.Addresses;
+using FitBridge_Application.Interfaces.Repositories;
+using MediatR;
+using AutoMapper;
+using FitBridge_Domain.Entities.Accounts;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Commons.Constants;
+using FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
+using FitBridge_Application.Dtos;
+
+namespace FitBridge_Application.Features.Addresses.GetAllShopAddress;
+
+public class GetAllShopAddressQueryHandler(IUnitOfWork unitOfWork, IMapper mapper, IApplicationUserService applicationUserService) : IRequestHandler<GetAllShopAddressQuery, PagingResultDto<AddressResponseDto>>
+{
+    public async Task<PagingResultDto<AddressResponseDto>> Handle(GetAllShopAddressQuery request, CancellationToken cancellationToken)
+    {
+        var adminAccounts = await applicationUserService.GetUsersByRoleAsync(ProjectConstant.UserRoles.Admin);
+        var adminAccountIds = adminAccounts.Select(x => x.Id).ToList();
+        var addresses = await unitOfWork.Repository<Address>().GetAllWithSpecificationAsync(new GetAllShopAddressSpec(adminAccountIds, request.Params));
+        var totalAddressesCount = await unitOfWork.Repository<Address>().CountAsync(new GetAllShopAddressSpec(adminAccountIds, request.Params));
+        return new PagingResultDto<AddressResponseDto>(totalAddressesCount, mapper.Map<List<AddressResponseDto>>(addresses));
+    }
+}

--- a/FitBridge_Application/Features/Addresses/UpdateAddress/UpdateAddressCommand.cs
+++ b/FitBridge_Application/Features/Addresses/UpdateAddress/UpdateAddressCommand.cs
@@ -9,15 +9,16 @@ public class UpdateAddressCommand : IRequest<AddressResponseDto>
 {
     [JsonIgnore]
     public Guid Id { get; set; }
-    public string ReceiverName { get; set; }
-    public string PhoneNumber { get; set; }
-    public string City { get; set; }
-    public string District { get; set; }
-    public string Ward { get; set; }
-    public string Street { get; set; }
-    public string HouseNumber { get; set; }
-    public string Note { get; set; }
+    public string? ReceiverName { get; set; }
+    public string? PhoneNumber { get; set; }
+    public string? City { get; set; }
+    public string? District { get; set; }
+    public string? Ward { get; set; }
+    public string? Street { get; set; }
+    public string? HouseNumber { get; set; }
+    public string? Note { get; set; }
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
     public string? GoogleMapAddressString { get; set; }
+    public bool? IsShopDefaultAddress { get; set; }
 }

--- a/FitBridge_Application/Features/Addresses/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/FitBridge_Application/Features/Addresses/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -5,32 +5,60 @@ using FitBridge_Application.Dtos.Addresses;
 using FitBridge_Domain.Entities.Accounts;
 using FitBridge_Domain.Exceptions;
 using AutoMapper;
+using FitBridge_Application.Specifications.Addresses.GetShopDefaultAddress;
+using FitBridge_Application.Commons.Constants;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
 
 namespace FitBridge_Application.Features.Addresses.UpdateAddress;
 
-public class UpdateAddressCommandHandler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<UpdateAddressCommand, AddressResponseDto>
+public class UpdateAddressCommandHandler(IUnitOfWork unitOfWork, IMapper mapper, IApplicationUserService applicationUserService) : IRequestHandler<UpdateAddressCommand, AddressResponseDto>
 {
     public async Task<AddressResponseDto> Handle(UpdateAddressCommand request, CancellationToken cancellationToken)
     {
-        var address = await unitOfWork.Repository<Address>().GetByIdAsync(request.Id);
-        if (address == null)
+        var addressEntity = await unitOfWork.Repository<Address>().GetByIdAsync(request.Id);
+        if (addressEntity == null)
         {
             throw new NotFoundException("Address not found");
         }
-        address.ReceiverName = request.ReceiverName ?? address.ReceiverName;
-        address.PhoneNumber = request.PhoneNumber ?? address.PhoneNumber;
-        address.City = request.City ?? address.City;
-        address.District = request.District ?? address.District;
-        address.Ward = request.Ward ?? address.Ward;
-        address.Street = request.Street ?? address.Street;
-        address.HouseNumber = request.HouseNumber ?? address.HouseNumber;
-        address.Note = request.Note ?? address.Note;
-        address.Latitude = request.Latitude ?? address.Latitude;
-        address.Longitude = request.Longitude ?? address.Longitude;
-        address.GoogleMapAddressString = request.GoogleMapAddressString ?? address.GoogleMapAddressString;
-        address.UpdatedAt = DateTime.UtcNow;
-        unitOfWork.Repository<Address>().Update(address);
+        if (request.IsShopDefaultAddress.HasValue)
+        {
+            if (request.IsShopDefaultAddress == true)
+            {
+                await SwitchShopDefaultAddress(addressEntity.Id);
+                addressEntity.IsShopDefaultAddress = true;
+            }
+            if(request.IsShopDefaultAddress == false)
+            {
+                throw new BusinessException("Shop default address cannot be disabled, please choose another address as shop default address for auto switch");
+            }
+        }
+        addressEntity.ReceiverName = request.ReceiverName ?? addressEntity.ReceiverName;
+        addressEntity.PhoneNumber = request.PhoneNumber ?? addressEntity.PhoneNumber;
+        addressEntity.City = request.City ?? addressEntity.City;
+        addressEntity.District = request.District ?? addressEntity.District;
+        addressEntity.Ward = request.Ward ?? addressEntity.Ward;
+        addressEntity.Street = request.Street ?? addressEntity.Street;
+        addressEntity.HouseNumber = request.HouseNumber ?? addressEntity.HouseNumber;
+        addressEntity.Note = request.Note ?? addressEntity.Note;
+        addressEntity.Latitude = request.Latitude ?? addressEntity.Latitude;
+        addressEntity.Longitude = request.Longitude ?? addressEntity.Longitude;
+        addressEntity.GoogleMapAddressString = request.GoogleMapAddressString ?? addressEntity.GoogleMapAddressString;
+        addressEntity.UpdatedAt = DateTime.UtcNow;
+        unitOfWork.Repository<Address>().Update(addressEntity);
         await unitOfWork.CommitAsync();
-        return mapper.Map<AddressResponseDto>(address);
+        return mapper.Map<AddressResponseDto>(addressEntity);
+    }
+    
+    public async Task SwitchShopDefaultAddress(Guid addressId)
+    {
+        var adminAccounts = await applicationUserService.GetUsersByRoleAsync(ProjectConstant.UserRoles.Admin);
+        var adminAccountIds = adminAccounts.Select(x => x.Id).ToList();
+        var addresses = await unitOfWork.Repository<Address>().GetAllWithSpecificationAsync(new GetAllShopAddressSpec(adminAccountIds, exceptAddressId: addressId));
+        foreach(var address in addresses)
+        {
+            address.IsShopDefaultAddress = false;
+            unitOfWork.Repository<Address>().Update(address);
+        }
     }
 }

--- a/FitBridge_Application/Features/Orders/CreateShippingOrder/CreateShippingOrderCommandHandler.cs
+++ b/FitBridge_Application/Features/Orders/CreateShippingOrder/CreateShippingOrderCommandHandler.cs
@@ -8,6 +8,7 @@ using FitBridge_Domain.Exceptions;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using FitBridge_Domain.Entities.Accounts;
+using FitBridge_Application.Specifications.Addresses.GetShopDefaultAddress;
 
 namespace FitBridge_Application.Features.Orders.CreateShippingOrder;
 
@@ -45,7 +46,7 @@ public class CreateShippingOrderCommandHandler : IRequestHandler<CreateShippingO
         {
             throw new BusinessException($"Order is already in {order.Status} status and cannot be shipped again");
         }
-        var shopAddress = await _unitOfWork.Repository<Address>().GetByIdAsync(Guid.Parse(ProjectConstant.DefaultShopAddressId));
+        var shopAddress = await _unitOfWork.Repository<Address>().GetBySpecificationAsync(new GetShopDefaultAddressSpec());
         if (shopAddress == null)
         {
             throw new NotFoundException("Shop address not found");

--- a/FitBridge_Application/Features/Orders/GetShippingPrice/GetShippingPriceCommandHandler.cs
+++ b/FitBridge_Application/Features/Orders/GetShippingPrice/GetShippingPriceCommandHandler.cs
@@ -4,6 +4,7 @@ using FitBridge_Application.Dtos.Orders;
 using FitBridge_Application.Dtos.Shippings;
 using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Specifications.Addresses.GetShopDefaultAddress;
 using FitBridge_Domain.Entities.Accounts;
 using FitBridge_Domain.Exceptions;
 using MediatR;
@@ -19,7 +20,7 @@ public class GetShippingPriceCommandHandler(IUnitOfWork _unitOfWork, IAhamoveSer
         {
             throw new NotFoundException("Address not found");
         }
-        var fromAddress = await _unitOfWork.Repository<Address>().GetByIdAsync(Guid.Parse(ProjectConstant.DefaultShopAddressId));
+        var fromAddress = await _unitOfWork.Repository<Address>().GetBySpecificationAsync(new GetShopDefaultAddressSpec());
         if (fromAddress == null)
         {
             throw new NotFoundException("From address not found");

--- a/FitBridge_Application/Specifications/Addresses/GetAllShopAddress/GetAllShopAddressParams.cs
+++ b/FitBridge_Application/Specifications/Addresses/GetAllShopAddress/GetAllShopAddressParams.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
+
+public class GetAllShopAddressParams : BaseParams
+{
+    public string? GoogleAddressSearchTerm { get; set; }
+}

--- a/FitBridge_Application/Specifications/Addresses/GetAllShopAddress/GetAllShopAddressSpec.cs
+++ b/FitBridge_Application/Specifications/Addresses/GetAllShopAddress/GetAllShopAddressSpec.cs
@@ -1,0 +1,26 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.Accounts;
+using FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
+namespace FitBridge_Application.Specifications.Addresses.GetAllShopAddress;
+
+public class GetAllShopAddressSpec : BaseSpecification<Address>
+{
+    public GetAllShopAddressSpec(List<Guid> adminAccountIds, GetAllShopAddressParams? parameters = null, Guid? exceptAddressId = null) : base(x =>
+    adminAccountIds.Contains(x.CustomerId)
+    && (parameters == null || parameters.GoogleAddressSearchTerm == null || x.GoogleMapAddressString.ToLower().Contains(parameters.GoogleAddressSearchTerm.ToLower()))
+    && x.IsEnabled
+    && (exceptAddressId == null || x.Id != exceptAddressId))
+    {
+        if(parameters != null)
+        {
+            if(parameters.DoApplyPaging)
+            {
+                AddPaging(parameters.Size * (parameters.Page - 1), parameters.Size);
+            } else {
+                parameters.Size = -1;
+                parameters.Page = -1;
+            }
+        }
+    }
+}

--- a/FitBridge_Application/Specifications/Addresses/GetShopDefaultAddress/GetShopDefaultAddressSpec.cs
+++ b/FitBridge_Application/Specifications/Addresses/GetShopDefaultAddress/GetShopDefaultAddressSpec.cs
@@ -1,0 +1,11 @@
+using System;
+using FitBridge_Domain.Entities.Accounts;
+
+namespace FitBridge_Application.Specifications.Addresses.GetShopDefaultAddress;
+
+public class GetShopDefaultAddressSpec : BaseSpecification<Address>
+{
+    public GetShopDefaultAddressSpec() : base(x => x.IsShopDefaultAddress == true)
+    {
+    }
+}

--- a/FitBridge_Domain/Entities/Accounts/Address.cs
+++ b/FitBridge_Domain/Entities/Accounts/Address.cs
@@ -19,6 +19,7 @@ public class Address : BaseEntity
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
     public string? GoogleMapAddressString { get; set; }
+    public bool IsShopDefaultAddress { get; set; }
     public ApplicationUser Customer { get; set; }
     public ICollection<Order> Orders { get; set; } = new List<Order>();
 }

--- a/FitBridge_Infrastructure/Configurations/AddressConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/AddressConfiguration.cs
@@ -19,7 +19,7 @@ public class AddressConfiguration : IEntityTypeConfiguration<Address>
         builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);
-
+        builder.Property(e => e.IsShopDefaultAddress).HasDefaultValue(false);
         builder.HasOne(e => e.Customer).WithMany(e => e.Addresses).HasForeignKey(e => e.CustomerId);
     }
 }


### PR DESCRIPTION
Introduces IsShopDefaultAddress to Address entity and related DTOs, enabling marking an address as the shop's default. Adds logic to prevent deletion or disabling of the shop default address, and implements endpoints and specifications for querying all shop addresses of admin accounts. Updates address creation and update flows to handle switching the shop default address, and refactors order shipping logic to use the new default address specification.