### PR TITLE
#245 Add auto-cancel and re-payment for expired orders

### DIFF
--- a/FitBridge_Application/Commons/Constants/ProjectConstant.cs
+++ b/FitBridge_Application/Commons/Constants/ProjectConstant.cs
@@ -39,6 +39,8 @@ public static class ProjectConstant
         public const string AutoFinishArrivedOrderAfterTime = "AutoFinishArrivedOrderAfterTime";
         public const string AutoMarkAsFeedbackAfterDays = "AutoMarkAsFeedbackAfterDays";
         public const string MaximumReviewImages = "MaximumReviewImages";
+        public const string PaymentLinkExpirationMinutes = "PaymentLinkExpirationMinutes";
+        public const string AutoCancelCreatedOrderAfterTime = "AutoCancelCreatedOrderAfterTime";
     }
     public const int MaxRetries = 3;
     public static class EmailTypes

--- a/FitBridge_Application/Features/Orders/UpdateOrderStatus/UpdateOrderStatusCommandHandler.cs
+++ b/FitBridge_Application/Features/Orders/UpdateOrderStatus/UpdateOrderStatusCommandHandler.cs
@@ -16,7 +16,7 @@ public class UpdateOrderStatusCommandHandler(IUnitOfWork _unitOfWork, IMapper _m
 {
     public async Task<OrderStatusResponseDto> Handle(UpdateOrderStatusCommand request, CancellationToken cancellationToken)
     {
-        var order = await _unitOfWork.Repository<Order>().GetByIdAsync(request.OrderId, includes: new List<string> { nameof(Order.OrderItems), "OrderItems.ProductDetail", "Transactions" });
+        var order = await _unitOfWork.Repository<Order>().GetByIdAsync(request.OrderId,false, includes: new List<string> { nameof(Order.OrderItems), "OrderItems.ProductDetail", "Transactions" });
         var paymentMethod = await _unitOfWork.Repository<PaymentMethod>().GetByIdAsync(order.Transactions.FirstOrDefault(t => t.TransactionType == TransactionType.ProductOrder)!.PaymentMethodId);
         if (order == null)
         {
@@ -43,6 +43,7 @@ public class UpdateOrderStatusCommandHandler(IUnitOfWork _unitOfWork, IMapper _m
             {
                 await _orderService.ReturnQuantityToProductDetail(order);
             }
+
         }
         if (request.Status == OrderStatus.CustomerNotReceived)
         {
@@ -62,10 +63,8 @@ public class UpdateOrderStatusCommandHandler(IUnitOfWork _unitOfWork, IMapper _m
             PreviousStatus = previousStatus,
         };
         _unitOfWork.Repository<OrderStatusHistory>().Insert(orderStatusHistory);
-        _unitOfWork.Repository<Order>().Update(order);
         await _unitOfWork.CommitAsync();
         return _mapper.Map<OrderStatusResponseDto>(orderStatusHistory);
     }
-    
 
 }

--- a/FitBridge_Application/Features/Payments/CancelPaymentCommand/CancelPaymentCommandHandler.cs
+++ b/FitBridge_Application/Features/Payments/CancelPaymentCommand/CancelPaymentCommandHandler.cs
@@ -17,7 +17,6 @@ public class CancelPaymentCommandHandler(IUnitOfWork _unitOfWork) : IRequestHand
         {
             throw new NotFoundException("Transaction not found");
         }
-        transactionEntity.Order.Status = OrderStatus.Cancelled;
         transactionEntity.Status = TransactionStatus.Failed;
         await _unitOfWork.CommitAsync();
         return true;

--- a/FitBridge_Application/Features/Payments/RePaidOrder/RePaidOrderCommand.cs
+++ b/FitBridge_Application/Features/Payments/RePaidOrder/RePaidOrderCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using FitBridge_Application.Dtos.Payments;
+using MediatR;
+
+namespace FitBridge_Application.Features.Payments.RePaidOrder;
+
+public class RePaidOrderCommand : IRequest<string>  
+{
+    public Guid OrderId { get; set; }
+}

--- a/FitBridge_Application/Features/Payments/RePaidOrder/RePaidOrderCommandHandler.cs
+++ b/FitBridge_Application/Features/Payments/RePaidOrder/RePaidOrderCommandHandler.cs
@@ -1,0 +1,195 @@
+using System;
+using FitBridge_Application.Dtos.Payments;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Application.Interfaces.Repositories;
+using MediatR;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Domain.Enums.Orders;
+using FitBridge_Application.Dtos.OrderItems;
+using AutoMapper;
+using FitBridge_Application.Services;
+using FitBridge_Domain.Entities.Gyms;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedAvailableByPtId;
+using FitBridge_Application.Specifications.GymCourses.GetGymCourseById;
+using FitBridge_Application.Specifications.Accounts;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByGymId;
+using FitBridge_Application.Specifications.FreelancePtPackages.GetFreelancePtPackageById;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedByFreelancePtId;
+using FitBridge_Application.Commons.Constants;
+using FitBridge_Domain.Entities.ServicePackages;
+using FitBridge_Application.Specifications.UserSubscriptions.GetUserSubscriptionByUserId;
+using FitBridge_Domain.Entities.Ecommerce;
+
+namespace FitBridge_Application.Features.Payments.RePaidOrder;
+
+public class RePaidOrderCommandHandler(IUnitOfWork _unitOfWork, IPayOSService _payOSService, IMapper _mapper, CouponService couponService, IApplicationUserService _applicationUserService, SystemConfigurationService systemConfigurationService, SubscriptionService subscriptionService, OrderService _orderService) : IRequestHandler<RePaidOrderCommand, string>
+{
+    public async Task<string> Handle(RePaidOrderCommand request, CancellationToken cancellationToken)
+    {
+        var order = await _unitOfWork.Repository<Order>().GetByIdAsync(request.OrderId, includes: new List<string> { nameof(Order.Transactions), "Account", "OrderItems" });
+        if (order == null)
+        {
+            throw new NotFoundException("Order not found");
+        }
+        if (order.Status != OrderStatus.Created)
+        {
+            throw new BusinessException("Order is not in created status, current status: " + order.Status);
+        }
+        var transactionToCheck = order.Transactions.FirstOrDefault(x => x.Status == TransactionStatus.Pending);
+        if (transactionToCheck == null)
+        {
+            throw new BusinessException("Order is not pending payment");
+        }
+        var paymentInfo = await _payOSService.GetPaymentInfoAsync(transactionToCheck.OrderCode.ToString());
+        if (paymentInfo.Data.Status == "PENDING" || paymentInfo.Data.Status == "PROCESSING")
+        {
+            return order.CheckoutUrl;
+        }
+        transactionToCheck.Status = TransactionStatus.Expired;
+
+        if (paymentInfo.Data.Status == "CANCELLED")
+        {
+            transactionToCheck.Status = TransactionStatus.Failed;
+        }
+        transactionToCheck.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<Transaction>().Update(transactionToCheck);
+        var orderItemDtos = _mapper.Map<List<OrderItemDto>>(order.OrderItems);
+        await GetAndValidateOrderItems(orderItemDtos, order.AccountId, order.CouponId, order.CustomerPurchasedIdToExtend);
+
+        var repaidPaymentResponse = await _payOSService.CreatePaymentLinkAsync(new CreatePaymentRequestDto
+        {
+            AccountId = order.AccountId,
+            SubTotalPrice = order.SubTotalPrice,
+            TotalAmountPrice = order.TotalAmount,
+            OrderItems = orderItemDtos,
+            PaymentMethodId = transactionToCheck.PaymentMethodId,
+        }, order.Account);
+        order.CheckoutUrl = repaidPaymentResponse.Data.CheckoutUrl;
+        await CreateNewTransaction(order, repaidPaymentResponse, transactionToCheck);
+        order.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<Order>().Update(order);
+        await _unitOfWork.CommitAsync();
+        return repaidPaymentResponse.Data.CheckoutUrl;
+    }
+    public async Task CreateNewTransaction(Order order, PaymentResponseDto paymentResponse, Transaction transactionToCheck)
+    {
+        var newTransaction = new Transaction
+        {
+            OrderCode = paymentResponse.Data.OrderCode,
+            Description = "Repayment for order " + order.Id,
+            PaymentMethodId = transactionToCheck.PaymentMethodId,
+            TransactionType = transactionToCheck.TransactionType,
+            Status = TransactionStatus.Pending,
+            OrderId = order.Id,
+            Amount = paymentResponse.Data.Amount,
+            UpdatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _unitOfWork.Repository<Transaction>().Insert(newTransaction);
+    }
+    
+     public async Task GetAndValidateOrderItems(List<OrderItemDto> OrderItems, Guid userId, Guid? couponId, Guid? customerPurchasedIdToExtend)
+    {
+        if (couponId != null)
+        {
+            await couponService.ApplyCouponAsync(userId, couponId.Value, OrderItems.Count);
+        }
+
+        foreach (var item in OrderItems)
+        {
+            if (item.GymCourseId != null)
+            {
+                var gymCoursePT = await _unitOfWork.Repository<GymCourse>().GetBySpecificationAsync(new GetGymCourseByIdSpecification(item.GymCourseId.Value));
+
+                if (gymCoursePT == null)
+                {
+                    throw new NotFoundException("Gym course PT not found");
+                }
+                item.ProductName = gymCoursePT.Name;
+
+                if (item.GymPtId != null)
+                {
+                    var gymPt = await _applicationUserService.GetUserWithSpecAsync(new GetAccountByIdSpecificationForUserProfile(item.GymPtId.Value));
+                    if (gymPt == null)
+                    {
+                        throw new NotFoundException("Gym PT not found");
+                    }
+                    var currentCourseCount = await _unitOfWork.Repository<CustomerPurchased>().CountAsync(new GetCustomerPurchasedAvailableByPtIdSpec(item.GymPtId.Value, null));
+                    if (currentCourseCount >= gymPt.PtMaxCourse)
+                    {
+                        throw new BusinessException($"Maximum course count reached for PT {gymPt.FullName}, current course count: {currentCourseCount}, maximum course count: {gymPt.PtMaxCourse}");
+                    }
+                }
+
+                var userPackage = await _unitOfWork.Repository<CustomerPurchased>().GetBySpecificationAsync(new GetCustomerPurchasedByGymIdSpec(gymCoursePT.GymOwnerId, userId));
+                if (userPackage != null && customerPurchasedIdToExtend == null)
+                {
+                    throw new PackageExistException($"Package of this gym still not expired, customer purchased id: {userPackage.Id}, package expiration date: {userPackage.ExpirationDate} please extend the package");
+                }
+            }
+
+            if (item.FreelancePTPackageId != null)
+            {
+                var freelancePTPackage = await _unitOfWork.Repository<FreelancePTPackage>().GetBySpecificationAsync(new GetFreelancePtPackageByIdSpec(item.FreelancePTPackageId.Value));
+                if (freelancePTPackage == null)
+                {
+                    throw new NotFoundException("Freelance PTPackage not found");
+                }
+                item.ProductName = freelancePTPackage.Name;
+                var userPackage = await _unitOfWork.Repository<CustomerPurchased>().GetBySpecificationAsync(new GetCustomerPurchasedByFreelancePtIdSpec(freelancePTPackage.PtId, userId));
+                if (userPackage != null && customerPurchasedIdToExtend == null)
+                {
+                    throw new PackageExistException($"Package of this freelance PT still not expired, customer purchased id: {userPackage.Id}, package expiration date: {userPackage.ExpirationDate} please extend the package");
+                }
+                var freelancePt = await _applicationUserService.GetByIdAsync(freelancePTPackage.PtId);
+                if (freelancePt == null)
+                {
+                    throw new NotFoundException("Freelance PT not found");
+                }
+                var currentCourseCount = await _unitOfWork.Repository<CustomerPurchased>().CountAsync(new GetCustomerPurchasedAvailableByPtIdSpec(null, freelancePTPackage.PtId));
+                if (currentCourseCount >= freelancePt.PtMaxCourse)
+                {
+                    throw new BusinessException($"Maximum course count reached for freelance PT {freelancePt.FullName}, current course count: {currentCourseCount}, maximum course count: {freelancePt.PtMaxCourse}");
+                }
+            }
+            if (item.SubscriptionPlansInformationId != null)
+            {
+                var maxHotResearchSubscription = (int)await systemConfigurationService.GetSystemConfigurationAutoConvertDataTypeAsync(ProjectConstant.SystemConfigurationKeys.HotResearchSubscriptionLimit);
+
+                var subscriptionPlansInformation = await _unitOfWork.Repository<SubscriptionPlansInformation>().GetByIdAsync(item.SubscriptionPlansInformationId.Value, includes: new List<string> { "FeatureKey" });
+                if (subscriptionPlansInformation == null)
+                {
+                    throw new NotFoundException("Subscription plans information not found");
+                }
+                if (subscriptionPlansInformation.FeatureKey.FeatureName == ProjectConstant.FeatureKeyNames.HotResearch)
+                {
+                    var numOfCurrentHotResearchSubscription = await subscriptionService.GetNumOfCurrentHotResearchSubscription();
+                    if (numOfCurrentHotResearchSubscription >= maxHotResearchSubscription)
+                    {
+                        throw new BusinessException("Maximum hot research subscription reached");
+                    }
+                }
+
+                var userSubscription = await _unitOfWork.Repository<UserSubscription>().GetBySpecificationAsync(new GetUserSubscriptionByUserIdSpec(userId, subscriptionPlansInformation.Id));
+                if (userSubscription != null)
+                {
+                    throw new DuplicateException($"User already has a subscription for this plan, subscription id: {userSubscription.Id}, subscription expiration date: {userSubscription.EndDate}");
+                }
+            }
+            if (item.ProductDetailId != null)
+            {
+                var productDetail = await _unitOfWork.Repository<ProductDetail>().GetByIdAsync(item.ProductDetailId.Value);
+                if (productDetail == null)
+                {
+                    throw new NotFoundException("Product detail not found");
+                }
+                if (productDetail.Quantity < item.Quantity)
+                {
+                    throw new BusinessException("Product quantity is not enough");
+                }
+                await _orderService.UpdateProductDetailQuantity(productDetail, item.Quantity);
+            }
+        }
+    }
+}

--- a/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
+++ b/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
@@ -20,4 +20,6 @@ public interface IScheduleJobServices
     Task<bool> ScheduleAutoRejectEditBookingRequestJob(Guid BookingRequestId, DateTime triggerTime);
     Task<bool> ScheduleAutoFinishArrivedOrderJob(Guid OrderId, DateTime triggerTime);
     Task<bool> ScheduleAutoMarkAsFeedbackJob(Guid OrderItemId, DateTime triggerTime);
+    Task<bool> ScheduleAutoCancelCreatedOrderJob(Guid OrderId);
+    Task<bool> ScheduleAutoUpdatePTCurrentCourseJob(Guid OrderItemId, DateOnly expirationDate);
 }

--- a/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
@@ -10,7 +10,14 @@ public class OrderItemMappingProfile : Profile
     public OrderItemMappingProfile()
     {
         CreateMap<OrderItemDto, OrderItem>();
-        CreateMap<OrderItem, OrderItemDto>();
+        CreateMap<OrderItem, OrderItemDto>()
+        .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.Price))
+        .ForMember(dest => dest.OriginalProductPrice, opt => opt.MapFrom(src => src.OriginalProductPrice))
+        .ForMember(dest => dest.ProductDetailId, opt => opt.MapFrom(src => src.ProductDetailId))
+        .ForMember(dest => dest.GymCourseId, opt => opt.MapFrom(src => src.GymCourseId))
+        .ForMember(dest => dest.SubscriptionPlansInformationId, opt => opt.MapFrom(src => src.SubscriptionPlansInformationId))
+        .ForMember(dest => dest.FreelancePTPackageId, opt => opt.MapFrom(src => src.FreelancePTPackageId))
+        .ForMember(dest => dest.GymPtId, opt => opt.MapFrom(src => src.GymPtId));
         CreateMap<OrderItem, OrderItemForProductOrderResponseDto>();
     }
 }

--- a/FitBridge_Application/Services/OrderService.cs
+++ b/FitBridge_Application/Services/OrderService.cs
@@ -1,12 +1,14 @@
-using System;
-using FitBridge_Domain.Entities.Orders;
-using FitBridge_Domain.Exceptions;
-using FitBridge_Application.Interfaces.Repositories;
-using FitBridge_Domain.Entities.Ecommerce;
+    using System;
+    using FitBridge_Domain.Entities.Orders;
+    using FitBridge_Domain.Exceptions;
+    using FitBridge_Application.Interfaces.Repositories;
+    using FitBridge_Domain.Entities.Ecommerce;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Application.Interfaces.Services;
 
 namespace FitBridge_Application.Services;
 
-public class OrderService(IUnitOfWork _unitOfWork)
+public class OrderService(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService)
 {
     public async Task<bool> ReturnQuantityToProductDetail(Order order)
     {
@@ -19,7 +21,41 @@ public class OrderService(IUnitOfWork _unitOfWork)
             }
             productDetail.Quantity += orderItem.Quantity;
             productDetail.SoldQuantity -= orderItem.Quantity;
+            productDetail.UpdatedAt = DateTime.UtcNow;
             _unitOfWork.Repository<ProductDetail>().Update(productDetail);
+        }
+        return true;
+    }
+
+    public async Task<bool> UpdateProductDetailQuantity(ProductDetail productDetail, int quantity)
+    {
+        productDetail.Quantity -= quantity;
+        productDetail.SoldQuantity += quantity;
+        productDetail.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<ProductDetail>().Update(productDetail);
+        return true;
+    }
+
+    public async Task<bool> UpdatePTCurrentCourse(ApplicationUser Pt)
+    {
+        Pt.PtCurrentCourse += 1;
+        Pt.UpdatedAt = DateTime.UtcNow;
+        await _applicationUserService.UpdateAsync(Pt);
+        return true;
+    }
+
+    public async Task<bool> ReturnQuantityToPT(Order order)
+    {
+        foreach (var orderItem in order.OrderItems)
+        {
+            var ptId = orderItem.GymPtId ?? orderItem.FreelancePTPackage.PtId;
+            var pt = await _applicationUserService.GetByIdAsync(ptId, null, true);
+            if (pt == null)
+            {
+                throw new NotFoundException("PT not found");
+            }
+            pt.PtCurrentCourse--;
+            return true;
         }
         return true;
     }

--- a/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
+++ b/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
@@ -33,6 +33,7 @@ namespace FitBridge_Domain.Entities.Identity
         public string? AvatarUrl { get; set; }
         public Guid? GymOwnerId { get; set; } //To know this gym pt belong to which gym owner
         public int PtMaxCourse { get; set; } // Constraint the maximum number of courses a gym pt or freelance pt can teach
+        public int PtCurrentCourse { get; set; } // Current number of courses a gym pt or freelance pt is teaching
         public int MinimumSlot { get; set; } // Minimum slot register perweek, control by gym owner account
         public DateTime LastSeen { get; set; }
         public bool IsActive { get; set; }

--- a/FitBridge_Domain/Enums/Orders/TransactionStatus.cs
+++ b/FitBridge_Domain/Enums/Orders/TransactionStatus.cs
@@ -5,6 +5,7 @@
         Success,
 
         Failed,
-        Pending
+        Pending,
+        Expired
     }
 }

--- a/FitBridge_Infrastructure/Jobs/Orders/CancelCreatedOrderJob.cs
+++ b/FitBridge_Infrastructure/Jobs/Orders/CancelCreatedOrderJob.cs
@@ -1,0 +1,48 @@
+using System;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Application.Interfaces.Repositories;
+using Quartz;
+using Microsoft.Extensions.Logging;
+using FitBridge_Domain.Enums.Orders;
+using FitBridge_Application.Services;
+
+namespace FitBridge_Infrastructure.Jobs.Orders;
+
+public class CancelCreatedOrderJob(ILogger<CancelCreatedOrderJob> _logger, IUnitOfWork _unitOfWork, OrderService orderService) : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var orderId = Guid.Parse(context.JobDetail.JobDataMap.GetString("orderId")
+            ?? throw new NotFoundException($"{nameof(CancelCreatedOrderJob)}_orderId"));
+        var order = await _unitOfWork.Repository<Order>().GetByIdAsync(orderId, includes: new List<string> { nameof(Order.OrderItems), "Transactions", "OrderItems.GymCourse", "OrderItems.FreelancePTPackage" });
+        if (order == null)
+        {
+            throw new NotFoundException("Order not found");
+        }
+        if(order.Status != OrderStatus.Created)
+        {
+            _logger.LogError("Order is not created, current status: {OrderStatus}", order.Status);
+            return;
+        }
+        if(order.Transactions.Any(t => t.TransactionType == TransactionType.ProductOrder))
+        {
+            await orderService.ReturnQuantityToProductDetail(order);
+        }
+        if(order.Transactions.Any(t => t.TransactionType == TransactionType.GymCourse || t.TransactionType == TransactionType.FreelancePTPackage))
+        {
+            await orderService.ReturnQuantityToPT(order);
+        }
+        order.Status = OrderStatus.Cancelled;
+        var transactionToUpdate = order.Transactions.FirstOrDefault(t => t.Status == TransactionStatus.Pending);
+        if(transactionToUpdate != null)
+        {
+            transactionToUpdate.Status = TransactionStatus.Failed;
+            transactionToUpdate.UpdatedAt = DateTime.UtcNow;
+            _unitOfWork.Repository<Transaction>().Update(transactionToUpdate);
+        }
+        order.UpdatedAt = DateTime.UtcNow;
+        _unitOfWork.Repository<Order>().Update(order);
+        await _unitOfWork.CommitAsync();
+    }
+}

--- a/FitBridge_Infrastructure/Jobs/Orders/UpdatePTCurrentCourseJob.cs
+++ b/FitBridge_Infrastructure/Jobs/Orders/UpdatePTCurrentCourseJob.cs
@@ -1,0 +1,48 @@
+using System;
+using Quartz;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Exceptions;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Application.Interfaces.Services;
+using Microsoft.Extensions.Logging;
+
+namespace FitBridge_Infrastructure.Jobs.Orders;
+
+public class UpdatePTCurrentCourseJob(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService, ILogger<UpdatePTCurrentCourseJob> _logger) : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var orderItemId = Guid.Parse(context.JobDetail.JobDataMap.GetString("orderItemId"));
+        var orderItem = await _unitOfWork.Repository<OrderItem>().GetByIdAsync(orderItemId, includes: new List<string> { "FreelancePTPackage" });
+        if (orderItem == null)
+        {
+            _logger.LogError("Order item not found");
+            return;
+        }
+        if (orderItem.GymPtId != null)
+        {
+            var pt = await _applicationUserService.GetByIdAsync(orderItem.GymPtId.Value, null, true);
+            if (pt == null)
+            {
+                _logger.LogError("PT not found");
+                return;
+            }
+            pt.PtCurrentCourse--;
+        }
+        else if (orderItem.FreelancePTPackageId != null)
+        {
+            var freelancePt = await _applicationUserService.GetByIdAsync(orderItem.FreelancePTPackage.PtId, null, true);
+            if (freelancePt == null)
+            {
+                _logger.LogError("Freelance PT not found");
+                return;
+            }
+            if(freelancePt.PtCurrentCourse > 0)
+            {
+                freelancePt.PtCurrentCourse--;
+            }
+        }
+        await _unitOfWork.CommitAsync();
+    }
+}

--- a/FitBridge_Infrastructure/Services/PayOSService.cs
+++ b/FitBridge_Infrastructure/Services/PayOSService.cs
@@ -22,13 +22,14 @@ using FitBridge_Application.Commons.Constants;
 using Quartz;
 using FitBridge_Infrastructure.Jobs;
 using JsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
+using FitBridge_Application.Services;
 
 namespace FitBridge_Infrastructure.Services;
 
 public class PayOSService : IPayOSService
 {
     private readonly PayOSSettings _settings;
-
+    private readonly SystemConfigurationService _systemConfigurationService;
     private readonly ILogger<PayOSService> _logger;
 
     private readonly IUnitOfWork _unitOfWork;
@@ -44,7 +45,8 @@ public class PayOSService : IPayOSService
         ILogger<PayOSService> logger,
         IUnitOfWork unitOfWork,
         ITransactionService transactionService,
-        ISchedulerFactory schedulerFactory)
+        ISchedulerFactory schedulerFactory,
+        SystemConfigurationService systemConfigurationService)
     {
         _settings = settings.Value;
         _logger = logger;
@@ -53,6 +55,7 @@ public class PayOSService : IPayOSService
         // Initialize PayOS SDK
         _payOS = new PayOS(_settings.ClientId, _settings.ApiKey, _settings.ChecksumKey);
         _schedulerFactory = schedulerFactory;
+        _systemConfigurationService = systemConfigurationService;
     }
 
     public async Task<PaymentResponseDto> CreatePaymentLinkAsync(CreatePaymentRequestDto request, ApplicationUser user)
@@ -72,6 +75,7 @@ public class PayOSService : IPayOSService
                 }
                 address = $"{addressEntity.Street}, {addressEntity.Ward}, {addressEntity.District}, {addressEntity.City}";
             }
+            var expirationMinutes =(int) await _systemConfigurationService.GetSystemConfigurationAutoConvertDataTypeAsync(ProjectConstant.SystemConfigurationKeys.PaymentLinkExpirationMinutes);
             var paymentData = new PaymentData(
                 orderCode: orderCode,
                 //amount: (int)request.TotalAmount,
@@ -80,7 +84,7 @@ public class PayOSService : IPayOSService
                 items: items,
                 cancelUrl: $"{_settings.CancelUrl}?code=01&message&orderCode={orderCode}&amount={request.TotalAmountPrice}",
                 returnUrl: $"{_settings.ReturnUrl}?code=00&message&orderCode={orderCode}&amount={request.TotalAmountPrice}",
-                expiredAt: DateTimeOffset.UtcNow.AddMinutes(_settings.ExpirationMinutes).ToUnixTimeSeconds(),
+                expiredAt: DateTimeOffset.UtcNow.AddMinutes(expirationMinutes).ToUnixTimeSeconds(),
                 buyerName: user.UserName,
                 buyerEmail: user.Email,
                 buyerPhone: user.PhoneNumber,


### PR DESCRIPTION
Introduces scheduled jobs to auto-cancel orders if payment is not completed within a configurable time, and adds a re-payment endpoint to generate new payment links for expired orders. Updates domain models and services to track and manage PT course limits, product quantities, and transaction statuses. Refactors payment and order logic to support these features and ensures proper cleanup and state management via Quartz jobs.