### PR TITLE
#245 Add summary statistics to product orders API response

### DIFF
--- a/FitBridge_API/Controllers/OrdersController.cs
+++ b/FitBridge_API/Controllers/OrdersController.cs
@@ -116,7 +116,12 @@ public class OrdersController(IMediator _mediator) : _BaseApiController
     public async Task<IActionResult> GetAllProductOrders([FromQuery] GetAllProductOrdersParams parameters)
     {
         var result = await _mediator.Send(new GetAllProductOrdersQuery { Params = parameters });
-        var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
-        return Ok(new BaseResponse<Pagination<GetAllProductOrderResponseDto>>(StatusCodes.Status200OK.ToString(), "Orders retrieved successfully", pagination));
+        var pagination = ResultWithPagination(result.ProductOrders.Items, result.ProductOrders.Total, parameters.Page, parameters.Size);
+        var response = new
+        {
+            result.SummaryProductOrder,
+            ProductOrders = pagination
+        };
+        return Ok(new BaseResponse<object>(StatusCodes.Status200OK.ToString(), "Orders retrieved successfully", response));
     }
 }

--- a/FitBridge_Application/Dtos/Orders/GetAllProductOrderResponseDto.cs
+++ b/FitBridge_Application/Dtos/Orders/GetAllProductOrderResponseDto.cs
@@ -7,6 +7,7 @@ namespace FitBridge_Application.Dtos.Orders;
 
 public class GetAllProductOrderResponseDto
 {
+    public SummaryProductOrderDto SummaryProductOrder { get; set; }
     public Guid Id { get; set; }
     public string CheckoutUrl { get; set; }
     public decimal SubTotalPrice { get; set; }

--- a/FitBridge_Application/Dtos/Orders/GetManageProductOrder.cs
+++ b/FitBridge_Application/Dtos/Orders/GetManageProductOrder.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Orders;
+
+public class GetManageProductOrder(SummaryProductOrderDto summaryProductOrder, PagingResultDto<GetAllProductOrderResponseDto> productOrders)
+{
+    public SummaryProductOrderDto SummaryProductOrder { get; private set; } = summaryProductOrder;
+    public PagingResultDto<GetAllProductOrderResponseDto> ProductOrders { get; private set; } = productOrders;
+}

--- a/FitBridge_Application/Dtos/Orders/SummaryProductOrderDto.cs
+++ b/FitBridge_Application/Dtos/Orders/SummaryProductOrderDto.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Orders;
+
+public class SummaryProductOrderDto
+{
+    public int totalProductOrders { get; set; }
+    public decimal totalProfit { get; set; }
+    public decimal totalRevenue { get; set; }
+    public int totalPending { get; set; }
+    public int totalCompleted { get; set; }
+    public int totalCancelled { get; set; }
+    public int totalShipping { get; set; }
+    public int totalArrived { get; set; }
+    public int totalFinished { get; set; }
+    public int totalInReturn { get; set; }
+    public int totalReturned { get; set; }
+    public int totalProcessing { get; set; }
+    public int totalCreated { get; set; }
+    public int totalAccepted { get; set; }
+    public int totalCustomerNotReceived { get; set; }
+}

--- a/FitBridge_Application/Features/Orders/GetAllProductOrder/GetAllProductOrdersQuery.cs
+++ b/FitBridge_Application/Features/Orders/GetAllProductOrder/GetAllProductOrdersQuery.cs
@@ -1,12 +1,11 @@
 using System;
-using FitBridge_Application.Dtos;
 using FitBridge_Application.Dtos.Orders;
 using FitBridge_Application.Specifications.Orders.GetAllProductOrders;
 using MediatR;
 
 namespace FitBridge_Application.Features.Orders.GetAllProductOrder;
 
-public class GetAllProductOrdersQuery : IRequest<PagingResultDto<GetAllProductOrderResponseDto>>
+public class GetAllProductOrdersQuery : IRequest<GetManageProductOrder>
 {
     public GetAllProductOrdersParams Params { get; set; } = null!;
 }

--- a/FitBridge_Application/Features/Orders/GetAllProductOrder/GetAllProductOrdersQueryHandler.cs
+++ b/FitBridge_Application/Features/Orders/GetAllProductOrder/GetAllProductOrdersQueryHandler.cs
@@ -6,17 +6,80 @@ using FitBridge_Application.Specifications.Orders.GetAllProductOrders;
 using MediatR;
 using AutoMapper;
 using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Enums.Orders;
 
 namespace FitBridge_Application.Features.Orders.GetAllProductOrder;
 
-public class GetAllProductOrdersQueryHandler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<GetAllProductOrdersQuery, PagingResultDto<GetAllProductOrderResponseDto>>
+public class GetAllProductOrdersQueryHandler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<GetAllProductOrdersQuery, GetManageProductOrder>
 {
-    public async Task<PagingResultDto<GetAllProductOrderResponseDto>> Handle(GetAllProductOrdersQuery request, CancellationToken cancellationToken)
+    public async Task<GetManageProductOrder> Handle(GetAllProductOrdersQuery request, CancellationToken cancellationToken)
     {
+        var summaryProductOrder = new SummaryProductOrderDto();
         var spec = new GetAllProductOrdersSpec(request.Params);
         var orders = await unitOfWork.Repository<Order>().GetAllWithSpecificationAsync(spec);
         var totalItems = await unitOfWork.Repository<Order>().CountAsync(spec);
         var dtos = mapper.Map<IReadOnlyList<GetAllProductOrderResponseDto>>(orders);
-        return new PagingResultDto<GetAllProductOrderResponseDto>(totalItems, dtos);
+        var productOrdersResponse = new PagingResultDto<GetAllProductOrderResponseDto>(totalItems, dtos);
+        await aggregateSummaryProductOrder(orders.ToList(), summaryProductOrder);
+        var getManageProductOrder = new GetManageProductOrder(summaryProductOrder, productOrdersResponse);
+
+        return getManageProductOrder;
+    }
+
+    public async Task aggregateSummaryProductOrder(List<Order> orders, SummaryProductOrderDto summaryProductOrder)
+    {
+        foreach (var order in orders)
+        {
+            summaryProductOrder.totalProductOrders++;
+            switch (order.Status)
+            {
+                case OrderStatus.Pending:
+                    summaryProductOrder.totalPending++;
+                    break;
+                case OrderStatus.Processing:
+                    summaryProductOrder.totalProcessing++;
+                    break;
+                case OrderStatus.Shipping:
+                    summaryProductOrder.totalShipping++;
+                    break;
+                case OrderStatus.Arrived:
+                    summaryProductOrder.totalArrived++;
+                    break;
+                case OrderStatus.Cancelled:
+                    summaryProductOrder.totalCancelled++;
+                    break;
+                case OrderStatus.Finished:
+                    summaryProductOrder.totalFinished++;
+                    summaryProductOrder.totalProfit += order.TotalAmount;
+                    break;
+                case OrderStatus.InReturn:
+                    summaryProductOrder.totalInReturn++;
+                    break;
+                case OrderStatus.Returned:
+                    summaryProductOrder.totalReturned++;
+                    break;
+                case OrderStatus.Created:
+                    summaryProductOrder.totalCreated++;
+                    break;
+                case OrderStatus.Accepted:
+                    summaryProductOrder.totalAccepted++;
+                    break;
+                case OrderStatus.CustomerNotReceived:
+                    summaryProductOrder.totalCustomerNotReceived++;
+                    break;
+                default:
+                    break;
+            }
+            summaryProductOrder.totalRevenue += order.TotalAmount;
+            if (order.Transactions.Count() == 0)
+            {
+                continue;
+            }
+            var paymentMethod = await unitOfWork.Repository<PaymentMethod>().GetByIdAsync(order.Transactions.OrderByDescending(o => o.CreatedAt).First().PaymentMethodId);
+            if (order.OrderStatusHistories.Any(o => o.Status == OrderStatus.Returned) && paymentMethod.MethodType == MethodType.COD)
+            {
+                summaryProductOrder.totalProfit -= order.ShippingFeeActualCost.Value;
+            }
+        }
     }
 }

--- a/FitBridge_Application/Specifications/Orders/GetAllProductOrders/GetAllProductOrdersSpec.cs
+++ b/FitBridge_Application/Specifications/Orders/GetAllProductOrders/GetAllProductOrdersSpec.cs
@@ -22,6 +22,7 @@ public class GetAllProductOrdersSpec : BaseSpecification<Order>
         AddInclude(x => x.OrderItems);
         AddInclude("OrderItems.ProductDetail");
         AddInclude(x => x.OrderStatusHistories);
+        AddInclude(x => x.Transactions);
         if(parameters.SortOrder == "asc")
         {
             AddOrderBy(x => x.CreatedAt);


### PR DESCRIPTION
Introduced SummaryProductOrderDto and GetManageProductOrder DTOs to provide aggregate statistics (e.g., total orders, revenue, profit, status counts) alongside paginated product order data. Updated OrdersController and query/handler logic to return both summary and paginated results. Adjusted specifications to include transactions for accurate summary calculations.