### PR TITLE
#245 Add identity card fields to user and contract features

### DIFF
--- a/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommand.cs
+++ b/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommand.cs
@@ -17,5 +17,8 @@ public class UpdateProfileCommand : IRequest<UpdateProfileResponseDto>
     public string? TaxCode { get; set; }
     public string? GymDescription { get; set; }
     public string? GymName { get; set; }
+    public string? IdentityCardPlace { get; set; }
+    public string? CitizenCardPermanentAddress { get; set; }
+    public string? CitizenIdNumber { get; set; }
     public UpdateUserDetailDto? UserDetail { get; set; }
 }

--- a/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommandHandler.cs
+++ b/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommandHandler.cs
@@ -42,6 +42,9 @@ public class UpdateProfileCommandHandler(IApplicationUserService applicationUser
             account.TaxCode = request.TaxCode ?? account.TaxCode;
             account.GymDescription = request.GymDescription ?? account.GymDescription;
             account.GymName = request.GymName ?? account.GymName;
+            account.IdentityCardPlace = request.IdentityCardPlace ?? account.IdentityCardPlace;
+            account.CitizenCardPermanentAddress = request.CitizenCardPermanentAddress ?? account.CitizenCardPermanentAddress;
+            account.CitizenIdNumber = request.CitizenIdNumber ?? account.CitizenIdNumber;
             account.UpdatedAt = DateTime.UtcNow;
             await _unitOfWork.CommitAsync();
         }

--- a/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommand.cs
+++ b/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommand.cs
@@ -9,11 +9,4 @@ public class CreateContractCommand : IRequest<Guid>
     public Guid CustomerId { get; set; }
     public DateOnly StartDate { get; set; }
     public DateOnly EndDate { get; set; }
-    public string FullName { get; set; }
-    public string IdentityCardNumber { get; set; }
-    public DateOnly IdentityCardDate { get; set; }
-    public string IdentityCardPlace { get; set; }
-    public string PermanentAddress { get; set; }
-    public string PhoneNumber { get; set; }
-    public string TaxCode { get; set; }
 }

--- a/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommandHandler.cs
+++ b/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommandHandler.cs
@@ -35,11 +35,29 @@ public class CreateContractCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
         {
             contractRecord.ContractType = ContractType.FreelancePT;
         }
-        var commissionRate =(decimal) await _systemConfigurationService.GetSystemConfigurationAutoConvertDataTypeAsync(ProjectConstant.SystemConfigurationKeys.CommissionRate);
+        await AggregateContractRecord(contractRecord, customer);
+        var commissionRate = (decimal)await _systemConfigurationService.GetSystemConfigurationAutoConvertDataTypeAsync(ProjectConstant.SystemConfigurationKeys.CommissionRate);
         contractRecord.CommissionPercentage = (int)(commissionRate * 100);
         contractRecord.ContractStatus = ContractStatus.Created;
         _unitOfWork.Repository<ContractRecord>().Insert(contractRecord);
         await _unitOfWork.CommitAsync();
         return contractRecord.Id;
+    }
+    
+    public async Task AggregateContractRecord(ContractRecord contractRecord, ApplicationUser customer)
+    {
+        contractRecord.FullName = customer.FullName;
+
+        contractRecord.IdentityCardNumber = customer.CitizenIdNumber ?? throw new ContractMissingInfoException("Customer identity card number is required please update profile of customer to complete this contract");
+
+        contractRecord.IdentityCardDate = customer.IdentityCardDate ?? throw new ContractMissingInfoException("Customer identity card date is required please update profile of customer to complete this contract");
+
+        contractRecord.IdentityCardPlace = customer.IdentityCardPlace ?? throw new ContractMissingInfoException("Customer identity card place is required please update profile of customer to complete this contract");
+
+        contractRecord.PermanentAddress = customer.CitizenCardPermanentAddress ?? throw new ContractMissingInfoException("Customer permanent address is required please update profile of customer to complete this contract");
+
+        contractRecord.PhoneNumber = customer.PhoneNumber ?? throw new ContractMissingInfoException("Customer phone number is required please update profile of customer to complete this contract");
+
+        contractRecord.TaxCode = customer.TaxCode ?? throw new ContractMissingInfoException("Customer tax code is required please update profile of customer to complete this contract");
     }
 }

--- a/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommand.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommand.cs
@@ -19,4 +19,7 @@ public class RegisterAccountCommand : IRequest<RegisterResponseDto>
     public string? FrontCitizenIdUrl { get; set; }
     public string? BackCitizenIdUrl { get; set; }
     public string? CitizenIdNumber { get; set; }
+    public string? IdentityCardPlace { get; set; }
+    public string? CitizenCardPermanentAddress { get; set; }
+    public DateOnly? IdentityCardDate { get; set; }
 }

--- a/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommandHandler.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommandHandler.cs
@@ -36,6 +36,9 @@ public class RegisterAccountCommandHandler(IApplicationUserService _applicationU
             EmailConfirmed = true,
             IsContractSigned = false,
             CitizenIdNumber = request.CitizenIdNumber?? null,
+            IdentityCardPlace = request.IdentityCardPlace ?? "",
+            CitizenCardPermanentAddress = request.CitizenCardPermanentAddress ?? "",
+            IdentityCardDate = request.IdentityCardDate ?? null,
         };
         if (request.FrontCitizenIdUrl != null)
         {

--- a/FitBridge_Application/Specifications/Orders/GetAllProductOrders/GetAllProductOrdersSpec.cs
+++ b/FitBridge_Application/Specifications/Orders/GetAllProductOrders/GetAllProductOrdersSpec.cs
@@ -21,6 +21,8 @@ public class GetAllProductOrdersSpec : BaseSpecification<Order>
         AddInclude(x => x.Coupon);
         AddInclude(x => x.OrderItems);
         AddInclude("OrderItems.ProductDetail");
+        AddInclude("OrderItems.ProductDetail.Weight");
+        AddInclude("OrderItems.ProductDetail.Flavour");
         AddInclude(x => x.OrderStatusHistories);
         AddInclude(x => x.Transactions);
         if(parameters.SortOrder == "asc")

--- a/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
+++ b/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
@@ -43,6 +43,9 @@ namespace FitBridge_Domain.Entities.Identity
         public string? FrontCitizenIdUrl { get; set; }
         public string? BackCitizenIdUrl { get; set; }
         public string? CitizenIdNumber { get; set; }
+        public string? IdentityCardPlace { get; set; }
+        public string? CitizenCardPermanentAddress { get; set; }
+        public DateOnly? IdentityCardDate { get; set; }
         public ApplicationUser? GymOwner { get; set; }
         public ICollection<ApplicationUser> GymPTs { get; set; } = new List<ApplicationUser>();
         public List<string> GymImages { get; set; } = new List<string>();

--- a/FitBridge_Domain/Exceptions/ContractMissingInfoException.cs
+++ b/FitBridge_Domain/Exceptions/ContractMissingInfoException.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace FitBridge_Domain.Exceptions;
+
+public class ContractMissingInfoException(string message) : BusinessException(message)
+{
+}

--- a/FitBridge_Infrastructure/Configurations/ApplicationUserConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/ApplicationUserConfiguration.cs
@@ -35,6 +35,9 @@ public class ApplicationUserConfiguration : IEntityTypeConfiguration<Application
         builder.Property(e => e.FrontCitizenIdUrl).IsRequired(false);
         builder.Property(e => e.BackCitizenIdUrl).IsRequired(false);
         builder.Property(e => e.CitizenIdNumber).IsRequired(false);
+        builder.Property(e => e.IdentityCardPlace).IsRequired(false);
+        builder.Property(e => e.CitizenCardPermanentAddress).IsRequired(false);
+        builder.Property(e => e.IdentityCardDate).IsRequired(false);
         builder.HasOne(e => e.GymOwner)
         .WithMany(e => e.GymPTs)
         .HasForeignKey(e => e.GymOwnerId)


### PR DESCRIPTION
Introduces new fields (IdentityCardPlace, CitizenCardPermanentAddress, CitizenIdNumber, IdentityCardDate) to ApplicationUser and related DTOs/commands for profile update and registration. Refactors contract creation to aggregate these fields from the user profile and throws a custom ContractMissingInfoException if required information is missing. Updates EF configuration and product order specification includes accordingly.