### PR TITLE
#245 Update DTOs and mappings for product order responses

### DIFF
--- a/FitBridge_Application/Dtos/OrderItems/OrderItemForProductOrderResponseDto.cs
+++ b/FitBridge_Application/Dtos/OrderItems/OrderItemForProductOrderResponseDto.cs
@@ -7,12 +7,11 @@ public class OrderItemForProductOrderResponseDto
 {
     public Guid Id { get; set; }
     public int Quantity { get; set; }
-
     public decimal Price { get; set; }
-
     public bool IsFeedback { get; set; }
     public Guid OrderId { get; set; }
     public Guid? ProductDetailId { get; set; }
+    public string ProductName { get; set; }
     public ProductDetailForAdminResponseDto ProductDetail { get; set; }
     public decimal? OriginalProductPrice { get; set; }
     public bool IsRefunded { get; set; }

--- a/FitBridge_Application/Dtos/Orders/GetAllProductOrderResponseDto.cs
+++ b/FitBridge_Application/Dtos/Orders/GetAllProductOrderResponseDto.cs
@@ -7,7 +7,6 @@ namespace FitBridge_Application.Dtos.Orders;
 
 public class GetAllProductOrderResponseDto
 {
-    public SummaryProductOrderDto SummaryProductOrder { get; set; }
     public Guid Id { get; set; }
     public string CheckoutUrl { get; set; }
     public decimal SubTotalPrice { get; set; }

--- a/FitBridge_Application/Dtos/ProductDetails/ProductDetailForSaleResponseDto.cs
+++ b/FitBridge_Application/Dtos/ProductDetails/ProductDetailForSaleResponseDto.cs
@@ -15,5 +15,4 @@ public class ProductDetailForSaleResponseDto
     public string CountryOfOrigin { get; set; }
     public string Description { get; set; }
     public List<ProductDetailForAdminResponseDto> ProductDetails { get; set; }
-    public List<ReviewProductResponseDto>? Reviews { get; set; }
 }

--- a/FitBridge_Application/Features/Products/GetProductDetailForSale/GetProductDetailForSaleQueryHandler.cs
+++ b/FitBridge_Application/Features/Products/GetProductDetailForSale/GetProductDetailForSaleQueryHandler.cs
@@ -2,6 +2,7 @@ using System;
 using AutoMapper;
 using FitBridge_Application.Commons.Constants;
 using FitBridge_Application.Dtos.ProductDetails;
+using FitBridge_Application.Dtos.Reviews;
 using FitBridge_Application.Interfaces.Repositories;
 using FitBridge_Application.Services;
 using FitBridge_Application.Specifications.Products.GetProductDetailForSale;
@@ -23,7 +24,8 @@ public class GetProductDetailForSaleQueryHandler(IUnitOfWork _unitOfWork, IMappe
         }
         var productDetailForSaleDto = _mapper.Map<ProductDetailForSaleResponseDto>(product);
         var productDetailDtos = new List<ProductDetailForAdminResponseDto>();
-        foreach (var productDetail in product.ProductDetails) {
+        foreach (var productDetail in product.ProductDetails)
+        {
             var productDetailDto = _mapper.Map<ProductDetailForAdminResponseDto>(productDetail);
             productDetailDto.DaysToExpire = productDetail.ExpirationDate.DayNumber - DateOnly.FromDateTime(DateTime.UtcNow).DayNumber;
             productDetailDto.IsNearExpired = productDetailDto.DaysToExpire <= nearExpiredDateProductWarning;

--- a/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
@@ -18,6 +18,7 @@ public class OrderItemMappingProfile : Profile
         .ForMember(dest => dest.SubscriptionPlansInformationId, opt => opt.MapFrom(src => src.SubscriptionPlansInformationId))
         .ForMember(dest => dest.FreelancePTPackageId, opt => opt.MapFrom(src => src.FreelancePTPackageId))
         .ForMember(dest => dest.GymPtId, opt => opt.MapFrom(src => src.GymPtId));
-        CreateMap<OrderItem, OrderItemForProductOrderResponseDto>();
+        CreateMap<OrderItem, OrderItemForProductOrderResponseDto>()
+        .ForMember(dest => dest.ProductName, opt => opt.MapFrom(src => src.ProductDetail.Product.Name));
     }
 }


### PR DESCRIPTION
Added ProductName to OrderItemForProductOrderResponseDto and updated mapping profile to populate it. Removed SummaryProductOrder from GetAllProductOrderResponseDto and Reviews from ProductDetailForSaleResponseDto. Minor code cleanup and import adjustments in GetProductDetailForSaleQueryHandler.