### PR TITLE
#245 Add contract deletion and enhance contract details

### DIFF
--- a/FitBridge_API/Controllers/ContractsController.cs
+++ b/FitBridge_API/Controllers/ContractsController.cs
@@ -3,6 +3,7 @@ using FitBridge_API.Helpers.RequestHelpers;
 using FitBridge_Application.Dtos.Contracts;
 using FitBridge_Application.Features.Contracts.ConfirmContract;
 using FitBridge_Application.Features.Contracts.CreateContract;
+using FitBridge_Application.Features.Contracts.DeleteContract;
 using FitBridge_Application.Features.Contracts.GetContract;
 using FitBridge_Application.Features.Contracts.UpdateContract;
 using FitBridge_Application.Specifications.Contracts.GetContract;
@@ -63,5 +64,13 @@ public class ContractsController(IMediator mediator) : _BaseApiController
         var result = await mediator.Send(new GetContractsQuery { Params = query });
         var pagination = ResultWithPagination(result.Items, result.Total, query.Page, query.Size);
         return Ok(new BaseResponse<Pagination<GetContractsDto>>(StatusCodes.Status200OK.ToString(), "Contracts retrieved successfully", pagination));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteContract([FromRoute] Guid id)
+    {
+        var command = new DeleteContractCommand { Id = id };
+        var result = await mediator.Send(command);
+        return Ok(new BaseResponse<bool>(StatusCodes.Status200OK.ToString(), "Contract deleted successfully", result));
     }
 }

--- a/FitBridge_Application/Dtos/Contracts/GetContractsDto.cs
+++ b/FitBridge_Application/Dtos/Contracts/GetContractsDto.cs
@@ -21,6 +21,10 @@ public class GetContractsDto
     public string? ContractUrl { get; set; }
     public string? CompanySignatureUrl { get; set; }
     public string? CustomerSignatureUrl { get; set; }
+    public string? BusinessAddress { get; set; }
+    public string? ContactEmail { get; set; }
+    public string? GymName { get; set; }
+    public List<string>? ExtraRules { get; set; } = new List<string>();
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public ContractStatus ContractStatus { get; set; }

--- a/FitBridge_Application/Features/Contracts/ConfirmContract/ConfirmContractCommandHandler.cs
+++ b/FitBridge_Application/Features/Contracts/ConfirmContract/ConfirmContractCommandHandler.cs
@@ -8,7 +8,7 @@ using FitBridge_Application.Interfaces.Services;
 
 namespace FitBridge_Application.Features.Contracts.ConfirmContract;
 
-public class ConfirmContractCommandHandler(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService) : IRequestHandler<ConfirmContractCommand, Guid>
+public class ConfirmContractCommandHandler(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService, IScheduleJobServices _scheduleJobServices) : IRequestHandler<ConfirmContractCommand, Guid>
 {
     public async Task<Guid> Handle(ConfirmContractCommand request, CancellationToken cancellationToken)
     {
@@ -29,7 +29,7 @@ public class ConfirmContractCommandHandler(IUnitOfWork _unitOfWork, IApplication
         customer.IsContractSigned = true;
         contract.ContractStatus = ContractStatus.Finished;
         contract.UpdatedAt = DateTime.UtcNow;
-        
+        await _scheduleJobServices.ScheduleAutoExpiredContractAccountJob(contract.Id, contract.EndDate.ToDateTime(TimeOnly.MaxValue));
         _unitOfWork.Repository<ContractRecord>().Update(contract);
         await _unitOfWork.CommitAsync();
         return contract.Id;

--- a/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommand.cs
+++ b/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommand.cs
@@ -8,5 +8,6 @@ public class CreateContractCommand : IRequest<Guid>
 {
     public Guid CustomerId { get; set; }
     public DateOnly StartDate { get; set; }
-    public DateOnly EndDate { get; set; }
+    public DateOnly EndDate { get; set; }    
+    public List<string>? ExtraRules { get; set; } = new List<string>();
 }

--- a/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommandHandler.cs
+++ b/FitBridge_Application/Features/Contracts/CreateContract/CreateContractCommandHandler.cs
@@ -43,7 +43,7 @@ public class CreateContractCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
         await _unitOfWork.CommitAsync();
         return contractRecord.Id;
     }
-    
+
     public async Task AggregateContractRecord(ContractRecord contractRecord, ApplicationUser customer)
     {
         contractRecord.FullName = customer.FullName;
@@ -59,5 +59,11 @@ public class CreateContractCommandHandler(IUnitOfWork _unitOfWork, IMapper _mapp
         contractRecord.PhoneNumber = customer.PhoneNumber ?? throw new ContractMissingInfoException("Customer phone number is required please update profile of customer to complete this contract");
 
         contractRecord.TaxCode = customer.TaxCode ?? throw new ContractMissingInfoException("Customer tax code is required please update profile of customer to complete this contract");
+
+        contractRecord.BusinessAddress = customer.BusinessAddress ?? throw new ContractMissingInfoException("Customer business address is required please update profile of customer to complete this contract");
+
+        contractRecord.ContactEmail = customer.Email ?? throw new ContractMissingInfoException("Customer contact email is required please update profile of customer to complete this contract");
+
+        contractRecord.GymName = customer.GymName;
     }
 }

--- a/FitBridge_Application/Features/Contracts/DeleteContract/DeleteContractCommand.cs
+++ b/FitBridge_Application/Features/Contracts/DeleteContract/DeleteContractCommand.cs
@@ -1,0 +1,9 @@
+using System;
+using MediatR;
+
+namespace FitBridge_Application.Features.Contracts.DeleteContract;
+
+public class DeleteContractCommand : IRequest<bool>
+{
+    public Guid Id { get; set; }
+}

--- a/FitBridge_Application/Features/Contracts/DeleteContract/DeleteContractCommandHandler.cs
+++ b/FitBridge_Application/Features/Contracts/DeleteContract/DeleteContractCommandHandler.cs
@@ -1,0 +1,27 @@
+using System;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Domain.Entities.Contracts;
+using FitBridge_Domain.Enums.Contracts;
+using FitBridge_Domain.Exceptions;
+using MediatR;
+
+namespace FitBridge_Application.Features.Contracts.DeleteContract;
+
+public class DeleteContractCommandHandler(IUnitOfWork _unitOfWork) : IRequestHandler<DeleteContractCommand, bool>
+{
+    public async Task<bool> Handle(DeleteContractCommand request, CancellationToken cancellationToken)
+    {
+        var contract = await _unitOfWork.Repository<ContractRecord>().GetByIdAsync(request.Id);
+        if (contract == null)
+        {
+            throw new NotFoundException("Contract not found");
+        }
+        if(contract.ContractStatus == ContractStatus.Finished)
+        {
+            throw new BusinessException("Contract is already finished and cannot be deleted");
+        }
+        _unitOfWork.Repository<ContractRecord>().SoftDelete(contract);
+        await _unitOfWork.CommitAsync();
+        return true;
+    }
+}

--- a/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommand.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommand.cs
@@ -1,5 +1,7 @@
 using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.Addresses;
 using FitBridge_Application.Dtos.Identities;
+using FitBridge_Application.Features.Addresses.CreateAddress;
 using MediatR;
 
 namespace FitBridge_Application.Features.Identities.Registers.RegisterAccounts;
@@ -22,4 +24,5 @@ public class RegisterAccountCommand : IRequest<RegisterResponseDto>
     public string? IdentityCardPlace { get; set; }
     public string? CitizenCardPermanentAddress { get; set; }
     public DateOnly? IdentityCardDate { get; set; }
+    public string? BusinessAddress { get; set; }
 }

--- a/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommandHandler.cs
+++ b/FitBridge_Application/Features/Identities/Registers/RegisterAccounts/RegisterAccountCommandHandler.cs
@@ -39,6 +39,7 @@ public class RegisterAccountCommandHandler(IApplicationUserService _applicationU
             IdentityCardPlace = request.IdentityCardPlace ?? null,
             CitizenCardPermanentAddress = request.CitizenCardPermanentAddress ?? null,
             IdentityCardDate = request.IdentityCardDate ?? null,
+            BusinessAddress = request.BusinessAddress ?? null,
         };
         if (request.FrontCitizenIdUrl != null)
         {

--- a/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
+++ b/FitBridge_Application/Interfaces/Services/IScheduleJobServices.cs
@@ -22,4 +22,5 @@ public interface IScheduleJobServices
     Task<bool> ScheduleAutoMarkAsFeedbackJob(Guid OrderItemId, DateTime triggerTime);
     Task<bool> ScheduleAutoCancelCreatedOrderJob(Guid OrderId);
     Task<bool> ScheduleAutoUpdatePTCurrentCourseJob(Guid OrderItemId, DateOnly expirationDate);
+    Task<bool> ScheduleAutoExpiredContractAccountJob(Guid ContractId, DateTime triggerTime);
 }

--- a/FitBridge_Domain/Entities/Contracts/ContractRecord.cs
+++ b/FitBridge_Domain/Entities/Contracts/ContractRecord.cs
@@ -17,10 +17,14 @@ public class ContractRecord : BaseEntity
     public string PermanentAddress { get; set; }
     public string PhoneNumber { get; set; }
     public string TaxCode { get; set; }
+    public string BusinessAddress { get; set; }
     public int CommissionPercentage { get; set; }
     public string? ContractUrl { get; set; }
     public string? CompanySignatureUrl { get; set; }
     public string? CustomerSignatureUrl { get; set; }
+    public string? ContactEmail { get; set; }
+    public string? GymName { get; set; }
+    public List<string>? ExtraRules { get; set; } = new List<string>();
     public ContractStatus ContractStatus { get; set; }
     public ApplicationUser Customer { get; set; }
 }

--- a/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
+++ b/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
@@ -46,6 +46,7 @@ namespace FitBridge_Domain.Entities.Identity
         public string? IdentityCardPlace { get; set; }
         public string? CitizenCardPermanentAddress { get; set; }
         public DateOnly? IdentityCardDate { get; set; }
+        public string? BusinessAddress { get; set; }
         public ApplicationUser? GymOwner { get; set; }
         public ICollection<ApplicationUser> GymPTs { get; set; } = new List<ApplicationUser>();
         public List<string> GymImages { get; set; } = new List<string>();

--- a/FitBridge_Infrastructure/Configurations/ApplicationUserConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/ApplicationUserConfiguration.cs
@@ -38,6 +38,7 @@ public class ApplicationUserConfiguration : IEntityTypeConfiguration<Application
         builder.Property(e => e.IdentityCardPlace).IsRequired(false);
         builder.Property(e => e.CitizenCardPermanentAddress).IsRequired(false);
         builder.Property(e => e.IdentityCardDate).IsRequired(false);
+        builder.Property(e => e.BusinessAddress).IsRequired(false);
         builder.HasOne(e => e.GymOwner)
         .WithMany(e => e.GymPTs)
         .HasForeignKey(e => e.GymOwnerId)

--- a/FitBridge_Infrastructure/Configurations/ContractRecordConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/ContractRecordConfiguration.cs
@@ -21,11 +21,13 @@ public class ContractRecordConfiguration : IEntityTypeConfiguration<ContractReco
         builder.Property(e => e.PermanentAddress).IsRequired();
         builder.Property(e => e.PhoneNumber).IsRequired();
         builder.Property(e => e.TaxCode).IsRequired();
+        builder.Property(e => e.BusinessAddress).IsRequired(false);
         builder.Property(e => e.CommissionPercentage).IsRequired();
         builder.Property(e => e.ContractUrl).IsRequired(false);
         builder.Property(e => e.CompanySignatureUrl).IsRequired(false);
         builder.Property(e => e.CustomerSignatureUrl).IsRequired(false);
         builder.Property(e => e.ContractStatus).HasConversion(convertToProviderExpression: s => s.ToString(), convertFromProviderExpression: s => Enum.Parse<ContractStatus>(s));
+        builder.Property(e => e.ExtraRules).IsRequired(false);
         builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);

--- a/FitBridge_Infrastructure/Jobs/Contracts/ExpireContractAccountJob.cs
+++ b/FitBridge_Infrastructure/Jobs/Contracts/ExpireContractAccountJob.cs
@@ -1,0 +1,30 @@
+using System;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Domain.Entities.Contracts;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Domain.Enums.Contracts;
+using FitBridge_Domain.Exceptions;
+using Quartz;
+
+namespace FitBridge_Infrastructure.Jobs.Contracts;
+
+public class ExpireContractAccountJob(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService) : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var contractId = Guid.Parse(context.JobDetail.JobDataMap.GetString("contractId") ?? throw new NotFoundException("Contract ID not found"));
+        var contract = await _unitOfWork.Repository<ContractRecord>().GetByIdAsync(contractId);
+        if (contract == null)
+        {
+            throw new NotFoundException("Contract not found");
+        }
+        var user = await _applicationUserService.GetByIdAsync(contract.CustomerId, isTracking: true);
+        if (user == null)
+        {
+            throw new NotFoundException($"User not found for contract {contractId}");
+        }
+        user.IsContractSigned = false;
+        await _unitOfWork.CommitAsync();
+    }
+}


### PR DESCRIPTION
Introduces DeleteContractCommand and its handler, enabling contract deletion via the API. Extends contract-related DTOs and entities to include business address, contact email, gym name, and extra rules. Adds scheduling for contract expiration jobs and updates related services, handlers, and configurations to support these features.