### PR TITLE
#245 Add endpoint to fetch expired contract users

### DIFF
--- a/FitBridge_API/Controllers/AccountsController.cs
+++ b/FitBridge_API/Controllers/AccountsController.cs
@@ -50,6 +50,9 @@ using FitBridge_Application.Specifications.GymSlotPts.GetGymPtRegisterSlotForGym
 using FitBridge_Application.Dtos.GymSlots;
 using FitBridge_Application.Specifications.GymSlotPts.GetGymSlotPtBooking;
 using FitBridge_Application.Features.GymSlots.GetGymSlotPtBooking;
+using FitBridge_Application.Specifications.Accounts.GetExpiredContractUser;
+using FitBridge_Application.Features.Accounts.GetExpiredContractUser;
+using FitBridge_Application.Dtos.Contracts;
 
 namespace FitBridge_API.Controllers;
 
@@ -402,5 +405,14 @@ public class AccountsController(IMediator _mediator, IUserUtil _userUtil) : _Bas
         var response = await _mediator.Send(new GetGymSlotPtBookingQuery(parameters));
         var pagination = ResultWithPagination(response.Items, response.Total, parameters.Page, parameters.Size);
         return Ok(new BaseResponse<Pagination<GymSlotPtBookingDto>>(StatusCodes.Status200OK.ToString(), "Gym PT bookings retrieved successfully", pagination));
+    }
+
+    [HttpGet("admin/expired-contract-users")]
+    [Authorize(Roles = ProjectConstant.UserRoles.Admin)]
+    public async Task<IActionResult> GetExpiredContractUsers([FromQuery] GetExpiredContractUserParams parameters)
+    {
+        var response = await _mediator.Send(new GetExpiredContractUserQuery(parameters));
+        var pagination = ResultWithPagination(response.Items, response.Total, parameters.Page, parameters.Size);
+        return Ok(new BaseResponse<Pagination<NonContractUserDto>>(StatusCodes.Status200OK.ToString(), "Expired contract users retrieved successfully", pagination));
     }
 }

--- a/FitBridge_Application/Dtos/Contracts/NonContractUserDto.cs
+++ b/FitBridge_Application/Dtos/Contracts/NonContractUserDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Contracts;
+
+public class NonContractUserDto
+{
+    public Guid Id { get; set; }
+    public string FullName { get; set; }
+    public string Role { get; set; }
+}

--- a/FitBridge_Application/Features/Accounts/GetExpiredContractUser/GetExpiredContractUserQuery.cs
+++ b/FitBridge_Application/Features/Accounts/GetExpiredContractUser/GetExpiredContractUserQuery.cs
@@ -1,0 +1,13 @@
+using System;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.Contracts;
+using FitBridge_Application.Specifications.Accounts.GetExpiredContractUser;
+using MediatR;
+
+namespace FitBridge_Application.Features.Accounts.GetExpiredContractUser;
+
+public class GetExpiredContractUserQuery(GetExpiredContractUserParams parameters) : IRequest<PagingResultDto<NonContractUserDto>>
+{
+    public GetExpiredContractUserParams Params { get; set; } = parameters;
+
+}

--- a/FitBridge_Application/Features/Accounts/GetExpiredContractUser/GetExpiredContractUserQueryHandler.cs
+++ b/FitBridge_Application/Features/Accounts/GetExpiredContractUser/GetExpiredContractUserQueryHandler.cs
@@ -1,0 +1,43 @@
+using System;
+using FitBridge_Application.Commons.Constants;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.Contracts;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Specifications.Accounts.GetExpiredContractUser;
+using FitBridge_Domain.Entities.Identity;
+using AutoMapper;
+using MediatR;
+
+namespace FitBridge_Application.Features.Accounts.GetExpiredContractUser;
+
+public class GetExpiredContractUserQueryHandler(IUnitOfWork _unitOfWork, IApplicationUserService _applicationUserService, IMapper _mapper) : IRequestHandler<GetExpiredContractUserQuery, PagingResultDto<NonContractUserDto>>
+{
+    public async Task<PagingResultDto<NonContractUserDto>> Handle(GetExpiredContractUserQuery request, CancellationToken cancellationToken)
+    {
+        var customerIds = new List<Guid>();
+        var gymOwners = await _applicationUserService.GetUsersByRoleAsync(ProjectConstant.UserRoles.GymOwner);
+        foreach (var gymOwner in gymOwners)
+        {
+            customerIds.Add(gymOwner.Id);
+        }
+        var freelancePts = await _applicationUserService.GetUsersByRoleAsync(ProjectConstant.UserRoles.FreelancePT);
+        foreach (var freelancePt in freelancePts)
+        {
+            customerIds.Add(freelancePt.Id);
+        }
+        var spec = new GetExpiredContractUserSpec(request.Params, customerIds);
+        var users = await _applicationUserService.GetAllUsersWithSpecAsync(spec);
+        var result = new List<NonContractUserDto>();
+        foreach (var user in users)
+        {
+            var nonContractUserDto = _mapper.Map<NonContractUserDto>(user);
+            nonContractUserDto.Role = await _applicationUserService.GetUserRoleAsync(user);
+            result.Add(nonContractUserDto);
+        }
+        
+        var count = await _applicationUserService.CountAsync(spec);
+        return new PagingResultDto<NonContractUserDto>(count, result);
+    }
+
+}

--- a/FitBridge_Application/MappingProfiles/ContractMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/ContractMappingProfile.cs
@@ -3,6 +3,7 @@ using FitBridge_Application.Features.Contracts.CreateContract;
 using FitBridge_Application.Dtos.Contracts;
 using FitBridge_Domain.Entities.Contracts;
 using AutoMapper;
+using FitBridge_Domain.Entities.Identity;
 
 namespace FitBridge_Application.MappingProfiles;
 
@@ -12,5 +13,8 @@ public class ContractMappingProfile : Profile
     {
         CreateMap<CreateContractCommand, ContractRecord>();
         CreateMap<ContractRecord, GetContractsDto>();
+        CreateMap<ApplicationUser, NonContractUserDto>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.FullName, opt => opt.MapFrom(src => src.FullName));
     }
 }

--- a/FitBridge_Application/Specifications/Accounts/GetExpiredContractUser/GetExpiredContractUserParams.cs
+++ b/FitBridge_Application/Specifications/Accounts/GetExpiredContractUser/GetExpiredContractUserParams.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace FitBridge_Application.Specifications.Accounts.GetExpiredContractUser;
+
+public class GetExpiredContractUserParams : BaseParams
+{
+    public Guid? CustomerId { get; set; }
+}

--- a/FitBridge_Application/Specifications/Accounts/GetExpiredContractUser/GetExpiredContractUserSpec.cs
+++ b/FitBridge_Application/Specifications/Accounts/GetExpiredContractUser/GetExpiredContractUserSpec.cs
@@ -1,0 +1,25 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Domain.Enums.Contracts;
+
+namespace FitBridge_Application.Specifications.Accounts.GetExpiredContractUser;
+
+public class GetExpiredContractUserSpec : BaseSpecification<ApplicationUser>
+{
+    public GetExpiredContractUserSpec(GetExpiredContractUserParams parameters, List<Guid> UserIds) : base(x => (parameters.CustomerId == null || x.Id == parameters.CustomerId)
+    && (x.ContractRecords.Count == 0 || !x.ContractRecords.Any(x => x.EndDate > DateOnly.FromDateTime(DateTime.UtcNow)))
+    && UserIds.Contains(x.Id))
+    {
+        AddInclude(x => x.ContractRecords);
+        if (parameters.DoApplyPaging)
+        {
+            AddPaging(parameters.Size * (parameters.Page - 1), parameters.Size);
+        }
+        else
+        {
+            parameters.Size = -1;
+            parameters.Page = -1;
+        }
+    }
+}


### PR DESCRIPTION
Introduces a new API endpoint for admins to retrieve users whose contracts have expired or who have no contracts. Adds supporting DTO, query, handler, mapping profile, and specifications to enable filtering and pagination of expired contract users.