### PR TITLE
#245 Add citizen ID URLs to profile update and restrict review edits

### DIFF
--- a/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommand.cs
+++ b/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommand.cs
@@ -25,5 +25,7 @@ public class UpdateProfileCommand : IRequest<UpdateProfileResponseDto>
     public DateOnly? GymFoundationDate { get; set; }
     public DateOnly? IdentityCardDate { get; set; }
     public string? BusinessAddress { get; set; }
+    public string? FrontCitizenIdUrl { get; set; }
+    public string? BackCitizenIdUrl { get; set; }
     public UpdateUserDetailDto? UserDetail { get; set; }
 }

--- a/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommandHandler.cs
+++ b/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommandHandler.cs
@@ -46,6 +46,8 @@ public class UpdateProfileCommandHandler(IApplicationUserService applicationUser
             account.GymFoundationDate = request.GymFoundationDate ?? account.GymFoundationDate;
             account.IdentityCardDate = request.IdentityCardDate ?? account.IdentityCardDate;
             account.BusinessAddress = request.BusinessAddress ?? account.BusinessAddress;
+            account.FrontCitizenIdUrl = request.FrontCitizenIdUrl ?? account.FrontCitizenIdUrl;
+            account.BackCitizenIdUrl = request.BackCitizenIdUrl ?? account.BackCitizenIdUrl;
             await _unitOfWork.CommitAsync();
         }
         catch (Exception ex)

--- a/FitBridge_Application/Features/Reviews/UpdateReview/UpdateReviewCommandHandler.cs
+++ b/FitBridge_Application/Features/Reviews/UpdateReview/UpdateReviewCommandHandler.cs
@@ -27,6 +27,10 @@ public class UpdateReviewCommandHandler(IUnitOfWork _unitOfWork, IUserUtil _user
         {
             throw new NotFoundException($"Review {request.ReviewId} not found");
         }
+        if(review.IsEdited)
+        {
+            throw new BusinessException("Review already edited");
+        }
         // if (review.UserId != userId.Value)
         // {
         //     throw new BusinessException("You are not allowed to update this review");


### PR DESCRIPTION
Added FrontCitizenIdUrl and BackCitizenIdUrl fields to UpdateProfileCommand and updated the handler to support these fields. In UpdateReviewCommandHandler, added a check to prevent editing a review that has already been edited.