### PR TITLE
#245 Add course order retrieval and gym/certificate entities

### DIFF
--- a/FitBridge_API/Controllers/OrdersController.cs
+++ b/FitBridge_API/Controllers/OrdersController.cs
@@ -5,11 +5,13 @@ using FitBridge_Application.Features.Orders.CancelShippingOrder;
 using FitBridge_Application.Features.Orders.CreateOrders;
 using FitBridge_Application.Features.Orders.CreateShippingOrder;
 using FitBridge_Application.Features.Orders.GetAllProductOrder;
+using FitBridge_Application.Features.Orders.GetCourseOrders;
 using FitBridge_Application.Features.Orders.GetOrderByCustomerPurchasedId;
 using FitBridge_Application.Features.Orders.GetShippingPrice;
 using FitBridge_Application.Features.Orders.ProcessAhamoveWebhook;
 using FitBridge_Application.Features.Orders.UpdateOrderStatus;
 using FitBridge_Application.Specifications.Orders.GetAllProductOrders;
+using FitBridge_Application.Specifications.Orders.GetCourseOrders;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -106,7 +108,7 @@ public class OrdersController(IMediator _mediator) : _BaseApiController
         var result = await _mediator.Send(command);
         return Ok(new BaseResponse<ShippingEstimateDto>(StatusCodes.Status200OK.ToString(), "Shipping price retrieved successfully", result));
     }
-    
+
     /// <summary>
     /// Get all product orders
     /// </summary>
@@ -123,5 +125,18 @@ public class OrdersController(IMediator _mediator) : _BaseApiController
             ProductOrders = pagination
         };
         return Ok(new BaseResponse<object>(StatusCodes.Status200OK.ToString(), "Orders retrieved successfully", response));
+    }
+    
+    /// <summary>
+    /// Get all course orders, can be freelance pt course or gym course of a customer
+    /// </summary>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    [HttpGet("course")]
+    public async Task<IActionResult> GetAllCourseOrders([FromQuery] GetCourseOrderParams parameters)
+    {
+        var result = await _mediator.Send(new GetCourseOrderQuery(parameters));
+        var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
+        return Ok(new BaseResponse<Pagination<CourseOrderResponseDto>>(StatusCodes.Status200OK.ToString(), "Course orders retrieved successfully", pagination));
     }
 }

--- a/FitBridge_Application/Dtos/FreelancePTPackages/GetFreelancePTPackageWithPt.cs
+++ b/FitBridge_Application/Dtos/FreelancePTPackages/GetFreelancePTPackageWithPt.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace FitBridge_Application.Dtos.FreelancePTPackages;
+
+public class GetFreelancePTPackageWithPt
+{
+        public Guid Id { get; set; }
+
+        public string Name { get; set; }
+
+        public decimal Price { get; set; }
+
+        public int DurationInDays { get; set; }
+
+        public int SessionDurationInMinutes { get; set; }
+
+        public int NumOfSessions { get; set; }
+
+        public string? Description { get; set; }
+
+        public string? ImageUrl { get; set; }
+
+        public Guid PtId { get; set; }
+        public string PtName { get; set; }
+        public string PtImageUrl { get; set; }
+}

--- a/FitBridge_Application/Dtos/GymCourses/GymCourseResponse.cs
+++ b/FitBridge_Application/Dtos/GymCourses/GymCourseResponse.cs
@@ -1,0 +1,18 @@
+using System;
+using FitBridge_Application.Dtos.GymPTs;
+
+namespace FitBridge_Application.Dtos.GymCourses;
+
+public class GymCourseResponse
+{
+    public Guid? Id { get; set; }
+    public string Name { get; set; }
+    public decimal Price { get; set; }
+    public decimal PtPrice { get; set; }
+    public Guid? GymPtId { get; set; }
+    public int Session { get; set; }
+    public string Description { get; set; }
+    public string ImageUrl { get; set; }
+    public Guid? GymOwnerId { get; set; }
+    public GymPtResponseDto? Pt { get; set; }
+}

--- a/FitBridge_Application/Dtos/OrderItems/OrderItemForCourseOrderResponseDto.cs
+++ b/FitBridge_Application/Dtos/OrderItems/OrderItemForCourseOrderResponseDto.cs
@@ -1,0 +1,20 @@
+using System;
+using FitBridge_Application.Dtos.FreelancePTPackages;
+using FitBridge_Application.Dtos.GymCourses;
+
+namespace FitBridge_Application.Dtos.OrderItems;
+
+public class OrderItemForCourseOrderResponseDto
+{
+    public Guid Id { get; set; }
+    public int Quantity { get; set; }
+    public decimal Price { get; set; }
+    public bool IsFeedback { get; set; }
+    public Guid OrderId { get; set; }
+    public Guid? GymCourseId { get; set; }
+    public Guid? FreelancePTPackageId { get; set; }
+    public string ProductName { get; set; }
+    public GetFreelancePTPackageWithPt? FreelancePTPackage { get; set; }
+    public GymCourseResponse? GymCourse { get; set; }
+    public bool IsRefunded { get; set; }
+}

--- a/FitBridge_Application/Dtos/Orders/CourseOrderResponseDto.cs
+++ b/FitBridge_Application/Dtos/Orders/CourseOrderResponseDto.cs
@@ -1,0 +1,19 @@
+using System;
+using FitBridge_Application.Dtos.OrderItems;
+using FitBridge_Domain.Enums.Orders;
+
+namespace FitBridge_Application.Dtos.Orders;
+
+public class CourseOrderResponseDto
+{
+    public Guid Id { get; set; }
+    public string CheckoutUrl { get; set; }
+    public decimal SubTotalPrice { get; set; }
+    public decimal TotalAmount { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? CouponId { get; set; }
+    public double DiscountPercent { get; set; }
+    public OrderStatus Status { get; set; }
+    public ICollection<OrderItemForCourseOrderResponseDto> OrderItems { get; set; } = new List<OrderItemForCourseOrderResponseDto>();
+}

--- a/FitBridge_Application/Dtos/Orders/GetManageProductOrder.cs
+++ b/FitBridge_Application/Dtos/Orders/GetManageProductOrder.cs
@@ -5,5 +5,5 @@ namespace FitBridge_Application.Dtos.Orders;
 public class GetManageProductOrder(SummaryProductOrderDto summaryProductOrder, PagingResultDto<GetAllProductOrderResponseDto> productOrders)
 {
     public SummaryProductOrderDto SummaryProductOrder { get; private set; } = summaryProductOrder;
-    public PagingResultDto<GetAllProductOrderResponseDto> ProductOrders { get; private set; } = productOrders;
+public PagingResultDto<GetAllProductOrderResponseDto> ProductOrders { get; private set; } = productOrders;
 }

--- a/FitBridge_Application/Features/Orders/GetCourseOrders/GetCourseOrderQuery.cs
+++ b/FitBridge_Application/Features/Orders/GetCourseOrders/GetCourseOrderQuery.cs
@@ -1,0 +1,12 @@
+using System;
+using FitBridge_Application.Dtos.Orders;
+using MediatR;
+using FitBridge_Application.Specifications.Orders.GetCourseOrders;
+using FitBridge_Application.Dtos;
+
+namespace FitBridge_Application.Features.Orders.GetCourseOrders;
+
+public class GetCourseOrderQuery(GetCourseOrderParams parameters) : IRequest<PagingResultDto<CourseOrderResponseDto>>
+{
+    public GetCourseOrderParams Parameters { get; set; } = parameters;
+}

--- a/FitBridge_Application/Features/Orders/GetCourseOrders/GetCourseOrderQueryHandler.cs
+++ b/FitBridge_Application/Features/Orders/GetCourseOrders/GetCourseOrderQueryHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.FreelancePTPackages;
+using FitBridge_Application.Dtos.GymCourses;
+using FitBridge_Application.Dtos.Orders;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Specifications.Orders.GetCourseOrders;
+using FitBridge_Domain.Entities.Orders;
+using MediatR;
+using AutoMapper;
+using AutoMapper.Configuration.Annotations;
+using FitBridge_Application.Dtos.OrderItems;
+using FitBridge_Application.Dtos.GymPTs;
+using FitBridge_Domain.Entities.Gyms;
+using FitBridge_Application.Specifications.GymCoursePts.GetGymCoursePtById;
+
+namespace FitBridge_Application.Features.Orders.GetCourseOrders;
+
+public class GetCourseOrderQueryHandler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<GetCourseOrderQuery, PagingResultDto<CourseOrderResponseDto>>
+{
+    public async Task<PagingResultDto<CourseOrderResponseDto>> Handle(GetCourseOrderQuery request, CancellationToken cancellationToken)
+    {
+        var spec = new GetCourseOrderSpec(request.Parameters);
+        var orders = await unitOfWork.Repository<Order>().GetAllWithSpecificationAsync(spec);
+        var orderDtos= new List<CourseOrderResponseDto>();
+        if (!request.Parameters.IsFreelancePtCourse)
+        {
+            foreach (var order in orders)
+            {
+                var orderDto = mapper.Map<CourseOrderResponseDto>(order);
+                foreach (var orderItem in order.OrderItems)
+                {
+                    var orderItemDto = mapper.Map<OrderItemForCourseOrderResponseDto>(orderItem);
+                    var gymCourseDto = mapper.Map<GymCourseResponse>(orderItem.GymCourse);
+                    if (orderItem.GymPtId != null)
+                    {
+                        var gymCoursePt = await unitOfWork.Repository<GymCoursePT>().GetBySpecificationAsync(new GetGymCoursePtByGymCourseIdAndPtIdSpec(orderItem.GymCourseId.Value, orderItem.GymPtId.Value));
+
+                        gymCourseDto.Session = gymCoursePt.Session ?? 0;
+                        gymCourseDto.GymPtId = orderItem.GymPtId;
+                        gymCourseDto.Pt = new GymPtResponseDto();
+                        gymCourseDto.Pt.Id = orderItem.GymPtId.Value;
+                        gymCourseDto.Pt.FullName = orderItem.GymPt.FullName;
+                        gymCourseDto.Pt.AvatarUrl = orderItem.GymPt.AvatarUrl;
+                        gymCourseDto.Pt.IsMale = orderItem.GymPt.IsMale;
+                        gymCourseDto.Pt.Dob = orderItem.GymPt.Dob;
+                        gymCourseDto.Pt.Experience = orderItem.GymPt.UserDetail!.Experience;
+                    }
+                    orderItemDto.GymCourse = gymCourseDto;
+                    orderItemDto.FreelancePTPackage = null;
+                    orderDto.OrderItems.Add(orderItemDto);
+                }
+                orderDtos.Add(orderDto);              
+            }
+        } else {
+            orderDtos = mapper.Map<List<CourseOrderResponseDto>>(orders);
+        }
+
+        var totalItems = await unitOfWork.Repository<Order>().CountAsync(spec);
+        return new PagingResultDto<CourseOrderResponseDto>(totalItems, orderDtos);
+    }
+}

--- a/FitBridge_Application/MappingProfiles/FreelancePTPackageMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/FreelancePTPackageMappingProfile.cs
@@ -11,6 +11,20 @@ namespace FitBridge_Application.MappingProfiles
             CreateMap<FreelancePTPackage, GetAllFreelancePTPackagesDto>();
             CreateMap<FreelancePTPackage, GetFreelancePTPackageByIdDto>();
             CreateMap<FreelancePTPackage, CreateFreelancePTPackageDto>();
+            CreateMap<FreelancePTPackage, GetFreelancePTPackageWithPt>()
+            .ForMember(dest => dest.PtName, opt => opt.MapFrom(src => src.Pt.FullName))
+            .ForMember(dest => dest.PtImageUrl, opt => opt.MapFrom(src => src.Pt.AvatarUrl))
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
+            .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.Price))
+            .ForMember(dest => dest.DurationInDays, opt => opt.MapFrom(src => src.DurationInDays))
+            .ForMember(dest => dest.SessionDurationInMinutes, opt => opt.MapFrom(src => src.SessionDurationInMinutes))
+            .ForMember(dest => dest.NumOfSessions, opt => opt.MapFrom(src => src.NumOfSessions))
+            .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+            .ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.ImageUrl))
+            .ForMember(dest => dest.PtId, opt => opt.MapFrom(src => src.PtId))
+            .ForMember(dest => dest.PtImageUrl, opt => opt.MapFrom(src => src.Pt.AvatarUrl))
+            .ForMember(dest => dest.PtName, opt => opt.MapFrom(src => src.Pt.FullName));
         }
     }
 }

--- a/FitBridge_Application/MappingProfiles/GymCoursePtMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/GymCoursePtMappingProfile.cs
@@ -2,6 +2,7 @@ using System;
 using AutoMapper;
 using FitBridge_Domain.Entities.Gyms;
 using FitBridge_Application.Dtos.GymCoursePts;
+using FitBridge_Application.Dtos.GymCourses;
 
 namespace FitBridge_Application.MappingProfiles;
 
@@ -16,5 +17,12 @@ public class GymCoursePtMappingProfile : Profile
             .ForMember(dest => dest.Session, opt => opt.MapFrom(src => src.Session))
             .ForMember(dest => dest.PtImageUrl, opt => opt.MapFrom(src => src.PT.AvatarUrl))
             .ForMember(dest => dest.PtName, opt => opt.MapFrom(src => src.PT.FullName));
+        CreateMap<GymCourse, GymCourseResponse>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
+            .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.Price))
+            .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+            .ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.ImageUrl))
+            .ForMember(dest => dest.GymOwnerId, opt => opt.MapFrom(src => src.GymOwnerId));
     }
 }

--- a/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
@@ -20,5 +20,9 @@ public class OrderItemMappingProfile : Profile
         .ForMember(dest => dest.GymPtId, opt => opt.MapFrom(src => src.GymPtId));
         CreateMap<OrderItem, OrderItemForProductOrderResponseDto>()
         .ForMember(dest => dest.ProductName, opt => opt.MapFrom(src => src.ProductDetail.Product.Name));
+
+        CreateMap<OrderItem, OrderItemForCourseOrderResponseDto>()
+        .ForMember(dest => dest.ProductName, opt => opt.MapFrom(src => src.GymCourse.Name))
+        .ForMember(dest => dest.FreelancePTPackage, opt => opt.MapFrom(src => src.FreelancePTPackage));
     }
 }

--- a/FitBridge_Application/MappingProfiles/OrderMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/OrderMappingProfile.cs
@@ -28,5 +28,15 @@ public class OrderMappingProfile : Profile
         .ForMember(dest => dest.CurrentStatus, opt => opt.MapFrom(src => src.Status))
         .ForMember(dest => dest.CouponId, opt => opt.MapFrom(src => src.CouponId))
         .ForMember(dest => dest.ShippingDetail, opt => opt.MapFrom(src => src.Address));
+        CreateMap<Order, CourseOrderResponseDto>()
+        .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+        .ForMember(dest => dest.CheckoutUrl, opt => opt.MapFrom(src => src.CheckoutUrl))
+        .ForMember(dest => dest.SubTotalPrice, opt => opt.MapFrom(src => src.SubTotalPrice))
+        .ForMember(dest => dest.TotalAmount, opt => opt.MapFrom(src => src.TotalAmount))
+        .ForMember(dest => dest.CreatedAt, opt => opt.MapFrom(src => src.CreatedAt))
+        .ForMember(dest => dest.UpdatedAt, opt => opt.MapFrom(src => src.UpdatedAt))
+        .ForMember(dest => dest.CouponId, opt => opt.MapFrom(src => src.CouponId))
+        .ForMember(dest => dest.DiscountPercent, opt => opt.MapFrom(src => src.Coupon != null ? src.Coupon.DiscountPercent : 0))
+        .ForMember(dest => dest.OrderItems, opt => opt.MapFrom(src => src.OrderItems));
     }
 }

--- a/FitBridge_Application/Specifications/Orders/GetAllProductOrders/GetAllProductOrdersParams.cs
+++ b/FitBridge_Application/Specifications/Orders/GetAllProductOrders/GetAllProductOrdersParams.cs
@@ -10,4 +10,5 @@ public class GetAllProductOrdersParams : BaseParams
     public DateTime? FromTime { get; set; }
     public DateTime? ToTime { get; set; }
     public string? ShippingTrackingId { get; set; }
+    public List<TransactionType>? TransactionTypes { get; set; }
 }

--- a/FitBridge_Application/Specifications/Orders/GetCourseOrders/GetCourseOrderParams.cs
+++ b/FitBridge_Application/Specifications/Orders/GetCourseOrders/GetCourseOrderParams.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace FitBridge_Application.Specifications.Orders.GetCourseOrders;
+
+public class GetCourseOrderParams : BaseParams
+{
+    public Guid? CustomerId { get; set; }
+    public bool IsFreelancePtCourse { get; set; } = false;
+    public DateTime? FromDate { get; set; }
+    public DateTime? ToDate { get; set; }
+    public Guid? OrderId { get; set; }
+}

--- a/FitBridge_Application/Specifications/Orders/GetCourseOrders/GetCourseOrderSpec.cs
+++ b/FitBridge_Application/Specifications/Orders/GetCourseOrders/GetCourseOrderSpec.cs
@@ -1,0 +1,46 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Enums.Orders;
+
+namespace FitBridge_Application.Specifications.Orders.GetCourseOrders;
+
+public class GetCourseOrderSpec : BaseSpecification<Order>
+{
+    public GetCourseOrderSpec(GetCourseOrderParams parameters) : base(x =>
+        (parameters.IsFreelancePtCourse ? x.OrderItems.Any(x => x.FreelancePTPackageId != null) : x.OrderItems.Any(x => x.GymCourseId != null)) &&
+        (parameters.CustomerId == null || x.AccountId == parameters.CustomerId) &&
+        (parameters.FromDate == null || x.CreatedAt >= parameters.FromDate) &&
+        (parameters.ToDate == null || x.CreatedAt <= parameters.ToDate) &&
+        (parameters.OrderId == null || x.Id == parameters.OrderId)
+        && x.Status == OrderStatus.Finished
+    )
+    {
+        AddInclude(x => x.OrderItems);
+        AddInclude(x => x.Coupon);
+        AddInclude("OrderItems.FreelancePTPackage");
+        AddInclude("OrderItems.GymCourse");
+        AddInclude("OrderItems.GymPt");
+        AddInclude("OrderItems.GymPt.UserDetail");
+        AddInclude("OrderItems.FreelancePTPackage.Pt.UserDetail");
+        AddInclude("OrderItems.FreelancePTPackage.Pt");        
+        if (parameters.SortOrder == "asc")
+        {
+            AddOrderBy(x => x.CreatedAt);
+        }
+        else
+        {
+            AddOrderByDesc(x => x.CreatedAt);
+        }
+
+        if (parameters.DoApplyPaging)
+        {
+            AddPaging((parameters.Page - 1) * parameters.Size, parameters.Size);
+        }
+        else
+        {
+            parameters.Size = -1;
+            parameters.Page = -1;
+        }
+    }
+}

--- a/FitBridge_Domain/Entities/Certificates/CertificateMetadata.cs
+++ b/FitBridge_Domain/Entities/Certificates/CertificateMetadata.cs
@@ -1,0 +1,15 @@
+using System;
+using FitBridge_Domain.Enums.Certificates;
+
+namespace FitBridge_Domain.Entities.Certificates;
+
+public class CertificateMetadata : BaseEntity
+{
+    public List<string> Specializations { get; set; } = new List<string>();
+    public CertificateType CertificateType { get; set; }
+    public string CertCode { get; set; }
+    public string CertName { get; set; }
+    public string ProviderName { get; set; }
+    public string Description { get; set; }
+    public ICollection<PtCertificates> PtCertificates { get; set; } = new List<PtCertificates>();
+}

--- a/FitBridge_Domain/Entities/Certificates/PtCertificates.cs
+++ b/FitBridge_Domain/Entities/Certificates/PtCertificates.cs
@@ -1,0 +1,19 @@
+using System;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Domain.Enums.Certificates;
+
+namespace FitBridge_Domain.Entities.Certificates;
+
+public class PtCertificates : BaseEntity
+{
+    public Guid PtId { get; set; }
+    public Guid CertificateMetadataId { get; set; }
+    public string CertUrl { get; set; }
+    public DateOnly ProvidedDate {get;set;}
+    public DateOnly? ExpirationDate{get;set;}
+    public CertificateStatus CertificateStatus { get; set; }
+    public CertificateMetadata CertificateMetadata { get; set; }
+
+    public ApplicationUser Pt { get; set; }
+
+}

--- a/FitBridge_Domain/Entities/Gyms/AssetMetadata.cs
+++ b/FitBridge_Domain/Entities/Gyms/AssetMetadata.cs
@@ -1,0 +1,14 @@
+using System;
+using FitBridge_Domain.Enums.Gyms;
+
+namespace FitBridge_Domain.Entities.Gyms;
+
+public class AssetMetadata : BaseEntity
+{
+    public string Name { get; set; }
+    public AssetType AssetType { get; set; }
+    public EquipmentCategoryType EquipmentCategoryType { get; set; }
+    public string Description { get; set; }
+    public List<string> TargetMuscularGroups { get; set; } = new List<string>();
+    public ICollection<GymAsset> GymAssets { get; set; } = new List<GymAsset>();
+}

--- a/FitBridge_Domain/Entities/Gyms/GymAsset.cs
+++ b/FitBridge_Domain/Entities/Gyms/GymAsset.cs
@@ -1,0 +1,15 @@
+using System;
+using FitBridge_Domain.Entities.Identity;
+
+namespace FitBridge_Domain.Entities.Gyms;
+
+public class GymAsset : BaseEntity
+{
+    public Guid GymOwnerId { get; set; }
+    public Guid AssetMetadataId { get; set; }
+    public int Quantity { get; set; }
+    public List<string> ImageUrls { get; set; } = new List<string>();
+    public ApplicationUser GymOwner { get; set; }
+    public AssetMetadata AssetMetadata { get; set; }
+
+}

--- a/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
+++ b/FitBridge_Domain/Entities/Identity/ApplicationUser.cs
@@ -12,6 +12,7 @@ using FitBridge_Domain.Entities.Reports;
 using FitBridge_Domain.Entities.Systems;
 using FitBridge_Domain.Entities.ServicePackages;
 using FitBridge_Domain.Entities.Contracts;
+using FitBridge_Domain.Entities.Certificates;
 
 namespace FitBridge_Domain.Entities.Identity
 {
@@ -85,6 +86,8 @@ namespace FitBridge_Domain.Entities.Identity
         public ICollection<SystemConfiguration> SystemConfigurations { get; set; } = new List<SystemConfiguration>();
         public ICollection<UserSubscription> UserSubscriptions { get; set; } = new List<UserSubscription>();
         public ICollection<ContractRecord> ContractRecords { get; set; } = new List<ContractRecord>();
+        public ICollection<PtCertificates> PtCertificates { get; set; } = new List<PtCertificates>();
+        public ICollection<GymAsset> GymAssets { get; set; } = new List<GymAsset>();
     }
 
 }

--- a/FitBridge_Domain/Enums/Certificates/CertificateStatus.cs
+++ b/FitBridge_Domain/Enums/Certificates/CertificateStatus.cs
@@ -1,0 +1,8 @@
+namespace FitBridge_Domain.Enums.Certificates;
+
+public enum CertificateStatus
+{
+    WaitingForReview,
+    Active,
+    Expired
+}

--- a/FitBridge_Domain/Enums/Certificates/CertificateType.cs
+++ b/FitBridge_Domain/Enums/Certificates/CertificateType.cs
@@ -1,0 +1,7 @@
+namespace FitBridge_Domain.Enums.Certificates;
+
+public enum CertificateType
+{
+    International,
+    Domestic
+}

--- a/FitBridge_Domain/Enums/Gyms/AssetType.cs
+++ b/FitBridge_Domain/Enums/Gyms/AssetType.cs
@@ -1,0 +1,10 @@
+using System;
+using FitBridge_Domain.Entities.Gyms;
+
+namespace FitBridge_Domain.Enums.Gyms;
+
+public enum AssetType
+{
+    Facility,
+    Equipment
+}

--- a/FitBridge_Domain/Enums/Gyms/EquipmentCategoryType.cs
+++ b/FitBridge_Domain/Enums/Gyms/EquipmentCategoryType.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace FitBridge_Domain.Enums.Gyms;
+
+public enum EquipmentCategoryType
+{
+    Cardio,
+    StrengthTraining,
+    FreeWeights,
+    Accessories
+}

--- a/FitBridge_Infrastructure/Configurations/AssetMetadataConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/AssetMetadataConfiguration.cs
@@ -1,0 +1,23 @@
+using System;
+using FitBridge_Domain.Entities.Gyms;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FitBridge_Infrastructure.Configurations;
+
+public class AssetMetadataConfiguration : IEntityTypeConfiguration<AssetMetadata>
+{
+    public void Configure(EntityTypeBuilder<AssetMetadata> builder)
+    {
+        builder.ToTable("AssetMetadata");
+        builder.Property(e => e.Name).IsRequired(true);
+        builder.Property(e => e.AssetType).IsRequired(true);
+        builder.Property(e => e.EquipmentCategoryType).IsRequired(true);
+        builder.Property(e => e.Description).IsRequired(true);
+        builder.Property(e => e.TargetMuscularGroups).IsRequired(true);
+        builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.IsEnabled).HasDefaultValue(true);
+    }
+
+}

--- a/FitBridge_Infrastructure/Configurations/CertificateMetadataConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/CertificateMetadataConfiguration.cs
@@ -1,0 +1,26 @@
+using System;
+using FitBridge_Domain.Entities.Certificates;
+using FitBridge_Domain.Enums.Certificates;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FitBridge_Infrastructure.Configurations;
+
+public class CertificateMetadataConfiguration : IEntityTypeConfiguration<CertificateMetadata>
+{
+    public void Configure(EntityTypeBuilder<CertificateMetadata> builder)
+    {
+        builder.ToTable("CertificateMetadata");
+        builder.Property(e => e.Specializations).IsRequired(true);
+        builder.Property(e => e.CertificateType).IsRequired(true)
+        .HasConversion(convertToProviderExpression: s => s.ToString(), convertFromProviderExpression: s => Enum.Parse<CertificateType>(s));
+        builder.Property(e => e.CertCode).IsRequired(true);
+        builder.Property(e => e.CertName).IsRequired(true);
+        builder.Property(e => e.ProviderName).IsRequired(true);
+        builder.Property(e => e.Description).IsRequired(true);
+        builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.IsEnabled).HasDefaultValue(true);
+    }
+
+}

--- a/FitBridge_Infrastructure/Configurations/GymAssetConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/GymAssetConfiguration.cs
@@ -1,0 +1,23 @@
+using System;
+using FitBridge_Domain.Entities.Gyms;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FitBridge_Infrastructure.Configurations;
+
+public class GymAssetConfiguration : IEntityTypeConfiguration<GymAsset>
+{
+    public void Configure(EntityTypeBuilder<GymAsset> builder)
+    {
+        builder.ToTable("GymAssets");
+        builder.Property(e => e.GymOwnerId).IsRequired(true);
+        builder.Property(e => e.AssetMetadataId).IsRequired(true);
+        builder.Property(e => e.Quantity).IsRequired(true);
+        builder.Property(e => e.ImageUrls).IsRequired(false);
+        builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.IsEnabled).HasDefaultValue(true);
+        builder.HasOne(e => e.GymOwner).WithMany(e => e.GymAssets).HasForeignKey(e => e.GymOwnerId);
+        builder.HasOne(e => e.AssetMetadata).WithMany(e => e.GymAssets).HasForeignKey(e => e.AssetMetadataId);
+    }
+}

--- a/FitBridge_Infrastructure/Configurations/PtCertificatesConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/PtCertificatesConfiguration.cs
@@ -1,0 +1,28 @@
+using System;
+using FitBridge_Domain.Entities.Certificates;
+using FitBridge_Domain.Enums.Certificates;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FitBridge_Infrastructure.Configurations;
+
+public class PtCertificatesConfiguration : IEntityTypeConfiguration<PtCertificates>
+{
+    public void Configure(EntityTypeBuilder<PtCertificates> builder)
+    {
+        builder.ToTable("PtCertificates");
+        builder.Property(e => e.PtId).IsRequired(true);
+        builder.Property(e => e.CertificateMetadataId).IsRequired(true);
+        builder.Property(e => e.CertUrl).IsRequired(true);
+        builder.Property(e => e.ProvidedDate).IsRequired(true);
+        builder.Property(e => e.ExpirationDate).IsRequired(false);
+        builder.Property(e => e.CertificateStatus).IsRequired(true)
+        .HasConversion(convertToProviderExpression: s => s.ToString(), convertFromProviderExpression: s => Enum.Parse<CertificateStatus>(s));
+        builder.Property(e => e.CreatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(e => e.IsEnabled).HasDefaultValue(true);
+        
+        builder.HasOne(e => e.Pt).WithMany(e => e.PtCertificates).HasForeignKey(e => e.PtId);
+        builder.HasOne(e => e.CertificateMetadata).WithMany(e => e.PtCertificates).HasForeignKey(e => e.CertificateMetadataId);
+    }
+}


### PR DESCRIPTION
Introduces endpoints and logic for retrieving course orders, including new DTOs, query handlers, and mapping profiles. Adds domain entities and configurations for gym assets and PT certificates, along with supporting enums. Updates existing mapping profiles and specifications to support new features and data structures.