### PR TITLE
Add member count validation and update query spec

### DIFF
--- a/FitBridge_Application/Features/Messaging/CreateConversation/CreateConversationCommandHandler.cs
+++ b/FitBridge_Application/Features/Messaging/CreateConversation/CreateConversationCommandHandler.cs
@@ -25,6 +25,10 @@ namespace FitBridge_Application.Features.Messaging.CreateConversation
             var senderAvatar = userUtil.GetAvatarUrl(httpContextAccessor.HttpContext)
                 ?? throw new NotFoundException("User avatar");
             var now = DateTime.UtcNow;
+            if (request.Members.Count < 2)
+            {
+                throw new DataValidationFailedException("Need at least 2 members");
+            }
             if (request.Members.Count > 2 && !request.IsGroup)
             {
                 throw new DataValidationFailedException("A conversation with more than 2 members must be a group.");

--- a/FitBridge_Application/Features/Messaging/GetConversations/GetConversationsQueryHandler.cs
+++ b/FitBridge_Application/Features/Messaging/GetConversations/GetConversationsQueryHandler.cs
@@ -67,7 +67,7 @@ internal class GetConversationsQueryHandler(
 
             var isActive = false;
             var convoMembers = await unitOfWork.Repository<ConversationMember>()
-                .GetAllWithSpecificationAsync(new GetOtherConversationMembersSpec(x.Id, userId), asNoTracking: true);
+                .GetAllWithSpecificationAsync(new GetOtherConversationMembersSpec(x.Id, userId, includeUser: true), asNoTracking: true);
 
             DateTime lastActiveAt = DateTime.UtcNow; // default to now if members are active
             var convoMemberUsers = convoMembers.Select(cm => cm.User).ToList();


### PR DESCRIPTION
Added validation to require at least two members when creating a conversation and updated the GetOtherConversationMembersSpec to include the user in GetConversationsQueryHandler. These changes improve data integrity and ensure correct member retrieval.
