### PR TITLE
#245 Enhance PT package management and add summary stats

### DIFF
--- a/FitBridge_API/Controllers/FreelancePTPackagesController.cs
+++ b/FitBridge_API/Controllers/FreelancePTPackagesController.cs
@@ -27,12 +27,16 @@ namespace FitBridge_API.Controllers
         public async Task<IActionResult> GetFreelancePTPackages([FromQuery] GetAllFreelancePTPackagesParam parameters)
         {
             var result = await mediator.Send(new GetAllFreelancePTPackagesQuery { Params = parameters });
-            var pagination = ResultWithPagination(result.Items, result.Total, parameters.Page, parameters.Size);
+            var pagination = ResultWithPagination(result.Packages.Items, result.Packages.Total, parameters.Page, parameters.Size);
             return Ok(
-                new BaseResponse<Pagination<GetAllFreelancePTPackagesDto>>(
+                new BaseResponse<object>(
                     StatusCodes.Status200OK.ToString(),
                     "Freelance PT Packages retrieved successfully",
-                    pagination));
+                    new
+                    {
+                        Packages = pagination,
+                        result.Summary
+                    }));
         }
 
         /// <summary>

--- a/FitBridge_Application/Commons/Constants/ProjectConstant.cs
+++ b/FitBridge_Application/Commons/Constants/ProjectConstant.cs
@@ -42,6 +42,7 @@ public static class ProjectConstant
         public const string MaximumReviewImages = "MaximumReviewImages";
         public const string PaymentLinkExpirationMinutes = "PaymentLinkExpirationMinutes";
         public const string AutoCancelCreatedOrderAfterTime = "AutoCancelCreatedOrderAfterTime";
+        public const string DefaultPtMaxCourse = "DefaultPtMaxCourse";
     }
     public const int MaxRetries = 3;
     public static class EmailTypes

--- a/FitBridge_Application/Dtos/Accounts/FreelancePts/GetAllFreelancePTsResponseDto.cs
+++ b/FitBridge_Application/Dtos/Accounts/FreelancePts/GetAllFreelancePTsResponseDto.cs
@@ -15,6 +15,8 @@ public class GetAllFreelancePTsResponseDto
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
     public decimal PriceFrom { get; set; }
+    public int PtMaxCourse { get; set; }
+    public int PtCurrentCourse { get; set; }
     public int ExperienceYears { get; set; }
     public int TotalPurchased { get; set; }
 }

--- a/FitBridge_Application/Dtos/Accounts/GetUserProfileResponse.cs
+++ b/FitBridge_Application/Dtos/Accounts/GetUserProfileResponse.cs
@@ -10,7 +10,7 @@ public class GetUserProfileResponse
     public string? Phone { get; set; }
 
     public DateTime? DOB { get; set; }
-            
+
     public double? Weight { get; set; }
 
     public double? Height { get; set; }
@@ -35,4 +35,6 @@ public class GetUserProfileResponse
     public string? BusinessAddress { get; set; }
     public TimeOnly? OpenTime { get; set; }
     public TimeOnly? CloseTime { get; set; }
+    public int? PtMaxCourse { get; set; }
+    public int? PtCurrentCourse { get; set; }
 }

--- a/FitBridge_Application/Dtos/Accounts/Profiles/UpdateProfileResponseDto.cs
+++ b/FitBridge_Application/Dtos/Accounts/Profiles/UpdateProfileResponseDto.cs
@@ -26,5 +26,6 @@ public class UpdateProfileResponseDto
     public List<string> GymImages { get; set; } = new List<string>();
     public TimeOnly? OpenTime { get; set; }
     public TimeOnly? CloseTime { get; set; }
+    public int? PtMaxCourse { get; set; }
     public UpdateUserDetailDto? UserDetail { get; set; }
 }

--- a/FitBridge_Application/Dtos/FreelancePTPackages/AllFreelancePTPackages.cs
+++ b/FitBridge_Application/Dtos/FreelancePTPackages/AllFreelancePTPackages.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace FitBridge_Application.Dtos.FreelancePTPackages;
+
+public class AllFreelancePTPackagesDto
+{
+    public FreelancePtPackageSummaryDto Summary { get; set; }
+    public PagingResultDto<GetAllFreelancePTPackagesDto> Packages { get; set; }
+}

--- a/FitBridge_Application/Dtos/FreelancePTPackages/FreelancePtPackageSummaryDto.cs
+++ b/FitBridge_Application/Dtos/FreelancePTPackages/FreelancePtPackageSummaryDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace FitBridge_Application.Dtos.FreelancePTPackages;
+
+public class FreelancePtPackageSummaryDto
+{
+    public int TotalPackages { get; set; }
+    public decimal TotalPrices { get; set; }
+    public decimal AveragePrice { get; set; }
+    public decimal AvgSessions { get; set; }
+    public int PtMaxCourse { get; set; }
+    public int PtCurrentCourse { get; set; }
+}   

--- a/FitBridge_Application/Dtos/FreelancePTPackages/GetAllFreelancePTPackagesDto.cs
+++ b/FitBridge_Application/Dtos/FreelancePTPackages/GetAllFreelancePTPackagesDto.cs
@@ -19,7 +19,8 @@
 
         public string? ImageUrl { get; set; }
         public bool? IsPurchased { get; set; }
-
+        public bool IsDisplayed { get; set; }
+        public int CurrentUserPurchased { get; set; }
         public Guid PtId { get; set; }
     }
 }

--- a/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommand.cs
+++ b/FitBridge_Application/Features/Accounts/UpdateProfiles/UpdateProfileCommand.cs
@@ -26,6 +26,7 @@ public class UpdateProfileCommand : IRequest<UpdateProfileResponseDto>
     public DateOnly? GymFoundationDate { get; set; }
     public DateOnly? IdentityCardDate { get; set; }
     public string? BusinessAddress { get; set; }
+    public int? PtMaxCourse { get; set; }
     public TimeOnly? OpenTime { get; set; }
     public TimeOnly? CloseTime { get; set; }
     public IFormFile? FrontCitizenIdFile { get; set; }

--- a/FitBridge_Application/Features/FreelancePTPackages/GetAllFreelancePTPackages/GetAllFreelancePTPackagesQuery.cs
+++ b/FitBridge_Application/Features/FreelancePTPackages/GetAllFreelancePTPackages/GetAllFreelancePTPackagesQuery.cs
@@ -5,7 +5,7 @@ using MediatR;
 
 namespace FitBridge_Application.Features.FreelancePTPackages.GetAllFreelancePTPackages
 {
-    public class GetAllFreelancePTPackagesQuery : IRequest<PagingResultDto<GetAllFreelancePTPackagesDto>>
+    public class GetAllFreelancePTPackagesQuery : IRequest<AllFreelancePTPackagesDto>
     {
         public GetAllFreelancePTPackagesParam Params { get; set; }
     }

--- a/FitBridge_Application/Features/FreelancePTPackages/UpdateFreelancePTPackage/UpdateFreelancePTPackageCommand.cs
+++ b/FitBridge_Application/Features/FreelancePTPackages/UpdateFreelancePTPackage/UpdateFreelancePTPackageCommand.cs
@@ -19,6 +19,7 @@ namespace FitBridge_Application.Features.FreelancePTPackages.UpdateFreelancePTPa
         public int? NumOfSessions { get; set; }
 
         public string? Description { get; set; }
+        public bool? IsDisplayed { get; set; }
 
         public string? ImageUrl { get; set; }
     }

--- a/FitBridge_Application/MappingProfiles/FreelancePTPackageMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/FreelancePTPackageMappingProfile.cs
@@ -9,6 +9,7 @@ namespace FitBridge_Application.MappingProfiles
         public FreelancePTPackageMappingProfile()
         {
             CreateMap<FreelancePTPackage, GetAllFreelancePTPackagesDto>();
+
             CreateMap<FreelancePTPackage, GetFreelancePTPackageByIdDto>();
             CreateMap<FreelancePTPackage, CreateFreelancePTPackageDto>();
             CreateMap<FreelancePTPackage, GetFreelancePTPackageWithPt>()

--- a/FitBridge_Application/Specifications/CustomerPurchaseds/GetAvailableCustomerPurchasedByFreelancePackage/GetAvailableCustomerPurchasedByFreelancePackageSpec.cs
+++ b/FitBridge_Application/Specifications/CustomerPurchaseds/GetAvailableCustomerPurchasedByFreelancePackage/GetAvailableCustomerPurchasedByFreelancePackageSpec.cs
@@ -1,0 +1,16 @@
+using System;
+using FitBridge_Application.Specifications;
+using FitBridge_Domain.Entities.Gyms;
+
+namespace FitBridge_Application.Specifications.CustomerPurchaseds.GetAvailableCustomerPurchasedByFreelancePackage;
+
+public class GetAvailableCustomerPurchasedByFreelancePackageSpec : BaseSpecification<CustomerPurchased>
+{
+    public GetAvailableCustomerPurchasedByFreelancePackageSpec(Guid freelancePTPackageId) : base(x =>
+        x.IsEnabled &&
+        x.OrderItems.Any(oi => oi.FreelancePTPackageId != null && oi.FreelancePTPackage!.Id == freelancePTPackageId) &&
+        x.ExpirationDate >= DateOnly.FromDateTime(DateTime.UtcNow))
+    {
+    }
+
+}

--- a/FitBridge_Application/Specifications/FreelancePtPackages/GetAllFreelancePTPackages/GetAllFreelancePTPackagesSpec.cs
+++ b/FitBridge_Application/Specifications/FreelancePtPackages/GetAllFreelancePTPackages/GetAllFreelancePTPackagesSpec.cs
@@ -9,6 +9,7 @@ namespace FitBridge_Application.Specifications.FreelancePtPackages.GetAllFreelan
             x.IsEnabled && x.PtId == ptId &&
             (string.IsNullOrEmpty(parameters.SearchTerm) || parameters.SearchTerm.ToLower().Contains(x.Name)))
         {
+            AddInclude(x => x.Pt);
             if (parameters.DoApplyPaging)
             {
                 AddPaging(parameters.Size * (parameters.Page - 1), parameters.Size - 1);

--- a/FitBridge_Domain/Entities/Gyms/FreelancePTPackage.cs
+++ b/FitBridge_Domain/Entities/Gyms/FreelancePTPackage.cs
@@ -14,6 +14,7 @@ public class FreelancePTPackage : BaseEntity
     public string? Description { get; set; }
     public string? ImageUrl { get; set; }
     public Guid PtId { get; set; }
+    public bool IsDisplayed { get; set; }
     public ApplicationUser Pt { get; set; }
     public ICollection<OrderItem> OrderItems { get; set; } = new List<OrderItem>();
 }

--- a/FitBridge_Infrastructure/Configurations/FreelancePTPackageConfiguration.cs
+++ b/FitBridge_Infrastructure/Configurations/FreelancePTPackageConfiguration.cs
@@ -20,7 +20,7 @@ public class FreelancePTPackageConfiguration : IEntityTypeConfiguration<Freelanc
         builder.Property(e => e.UpdatedAt).HasDefaultValueSql("NOW()");
         builder.Property(e => e.IsEnabled).HasDefaultValue(true);
         builder.Property(e => e.SessionDurationInMinutes).HasDefaultValue(60);
-        
+        builder.Property(e => e.IsDisplayed).HasDefaultValue(true);
         builder.Property(e => e.PtId).IsRequired(true);
         builder.HasOne(e => e.Pt).WithMany(e => e.PTFreelancePackages).HasForeignKey(e => e.PtId);
     }


### PR DESCRIPTION
Added support for PT max/current course tracking and validation, introduced summary statistics for freelance PT packages, and enabled display toggling for packages. Updated related DTOs, handlers, and specifications to support these features, and enforced business rules for updating session counts. Also included new configuration and mapping changes to support the new fields.