### PR TITLE
Remove Balance property from AvailableBalanceTransactionDto

### DIFF
--- a/FitBridge_Application/Dtos/Dashboards/AvailableBalanceTransactionDto.cs
+++ b/FitBridge_Application/Dtos/Dashboards/AvailableBalanceTransactionDto.cs
@@ -18,8 +18,6 @@
 
         public string? CourseName { get; set; } // aka. order item name
 
-        public decimal Balance { get; set; }
-
         public string? Description { get; set; }
     }
 }

--- a/FitBridge_Application/Features/Dashboards/GetAvailableBalanceDetail/GetAvailableBalanceDetailQueryHandler.cs
+++ b/FitBridge_Application/Features/Dashboards/GetAvailableBalanceDetail/GetAvailableBalanceDetailQueryHandler.cs
@@ -68,7 +68,6 @@ namespace FitBridge_Application.Features.Dashboards.GetAvailableBalanceDetail
                     ActualDistributionDate = isWithdrawal ? null : transaction.OrderItem!.ProfitDistributeActualDate,
                     WithdrawDate = isWithdrawal && transaction.WithdrawalRequest != null ? transaction.WithdrawalRequest.CreatedAt : null, // by the time admin approved
                     WithdrawalRequestId = isWithdrawal ? transaction.WithdrawalRequestId : null,
-                    Balance = userWallet.AvailableBalance, // Show current available balance from wallet
                     Description = transaction.Description
                 };
             }).ToList();

--- a/FitBridge_Application/Specifications/Dashboards/GetTransactionForAvailableBalanceDetail/GetTransactionForAvailableBalanceDetailSpec.cs
+++ b/FitBridge_Application/Specifications/Dashboards/GetTransactionForAvailableBalanceDetail/GetTransactionForAvailableBalanceDetailSpec.cs
@@ -23,6 +23,7 @@ namespace FitBridge_Application.Specifications.Dashboards.GetTransactionForAvail
             AddInclude("OrderItem.GymCourse");
             AddInclude("OrderItem.FreelancePTPackage");
             AddInclude("OrderItem.Order");
+            AddInclude(x => x.WithdrawalRequest);
 
             AddOrderBy(x => x.CreatedAt);
 


### PR DESCRIPTION
Eliminated the Balance property from AvailableBalanceTransactionDto and its usage in GetAvailableBalanceDetailQueryHandler to simplify the DTO. Also added WithdrawalRequest include in GetTransactionForAvailableBalanceDetailSpec for improved data retrieval.
