### PR TITLE
Fix profit sign for non-withdrawal transactions

### DIFF
--- a/FitBridge_Application/Features/Dashboards/GetAvailableBalanceDetail/GetAvailableBalanceDetailQueryHandler.cs
+++ b/FitBridge_Application/Features/Dashboards/GetAvailableBalanceDetail/GetAvailableBalanceDetailQueryHandler.cs
@@ -63,7 +63,7 @@ namespace FitBridge_Application.Features.Dashboards.GetAvailableBalanceDetail
                     OrderItemId = isWithdrawal ? null : transaction.OrderItemId!.Value,
                     CourseName = GetCourseName(),
                     TransactionId = transaction.Id,
-                    TotalProfit = transaction.Amount,
+                    TotalProfit = isWithdrawal ? transaction.Amount : transaction.Amount * -1,
                     TransactionType = transaction.TransactionType.ToString(),
                     ActualDistributionDate = isWithdrawal ? null : transaction.OrderItem!.ProfitDistributeActualDate,
                     WithdrawDate = isWithdrawal && transaction.WithdrawalRequest != null ? transaction.WithdrawalRequest.CreatedAt : null, // by the time admin approved


### PR DESCRIPTION
TotalProfit is now negative for non-withdrawal transactions to correctly reflect profit direction. Previously, all transactions used the same sign, which could cause reporting inaccuracies.
