### PR TITLE
Remove Dob property from gym DTOs and mappings

### DIFF
--- a/FitBridge_Application/Dtos/Accounts/Search/GetAllGymsForSearchDto.cs
+++ b/FitBridge_Application/Dtos/Accounts/Search/GetAllGymsForSearchDto.cs
@@ -5,23 +5,21 @@ namespace FitBridge_Application.Dtos.Accounts.Search;
 
 public class GetAllGymsForSearchDto
 {
-        public Guid Id { get; set; }
+    public Guid Id { get; set; }
 
-        public string GymName { get; set; } = string.Empty;
+    public string GymName { get; set; } = string.Empty;
 
-        public string RepresentName { get; set; } = string.Empty;
+    public string RepresentName { get; set; } = string.Empty;
 
-        public DateOnly Dob { get; set; }
+    public string GymAddress { get; set; } = string.Empty;
 
-        public string GymAddress { get; set; } = string.Empty;
+    public List<GymImageDto> GymImages { get; set; } = [];
 
-        public List<GymImageDto> GymImages { get; set; } = [];
+    public double Longitude { get; set; } = 0.0;
 
-        public double Longitude { get; set; } = 0.0;
+    public double Latitude { get; set; } = 0.0;
 
-        public double Latitude { get; set; } = 0.0;
+    public bool HotResearch { get; set; } = false;
 
-        public bool HotResearch { get; set; } = false;
-
-        public string GymDescription { get; set; } = string.Empty;
+    public string GymDescription { get; set; } = string.Empty;
 }

--- a/FitBridge_Application/Dtos/Gym/GetAllGymsDto.cs
+++ b/FitBridge_Application/Dtos/Gym/GetAllGymsDto.cs
@@ -8,8 +8,6 @@
 
         public string RepresentName { get; set; } = string.Empty;
 
-        public DateOnly Dob { get; set; }
-
         public string GymAddress { get; set; } = string.Empty;
 
         public List<GymImageDto> GymImages { get; set; } = [];

--- a/FitBridge_Application/Dtos/Gym/GetGymDetailsDto.cs
+++ b/FitBridge_Application/Dtos/Gym/GetGymDetailsDto.cs
@@ -8,8 +8,6 @@
 
         public string RepresentName { get; set; } = string.Empty;
 
-        public DateOnly Dob { get; set; }
-
         public string GymAddress { get; set; } = string.Empty;
 
         public List<GymImageDto> GymImages { get; set; } = [];

--- a/FitBridge_Application/MappingProfiles/GymMappingProfiles.cs
+++ b/FitBridge_Application/MappingProfiles/GymMappingProfiles.cs
@@ -14,16 +14,12 @@ namespace FitBridge_Application.MappingProfiles
         public GymMappingProfiles()
         {
             CreateProjection<ApplicationUser, GetGymDetailsDto>()
-                .ForMember(dest => dest.Dob, opt => opt.MapFrom(
-                    src => new DateOnly(src.Dob.Year, src.Dob.Month, src.Dob.Day)))
                 .ForMember(dest => dest.GymImages, opt => opt.MapFrom(
                     src => src.GymImages.Select(gi => new GymImageDto { Url = gi }).ToList()))
                 .ForMember(dest => dest.RepresentName, opt => opt.MapFrom(
                     src => src.FullName));
 
             CreateProjection<ApplicationUser, GetAllGymsDto>()
-                .ForMember(dest => dest.Dob, opt => opt.MapFrom(
-                    src => new DateOnly(src.Dob.Year, src.Dob.Month, src.Dob.Day)))
                 .ForMember(dest => dest.GymImages, opt => opt.MapFrom(
                     src => src.GymImages.Select(gi => new GymImageDto { Url = gi }).ToList()))
                 .ForMember(dest => dest.RepresentName, opt => opt.MapFrom(
@@ -46,8 +42,6 @@ namespace FitBridge_Application.MappingProfiles
                     src => src.UserDetail!.Experience));
 
             CreateMap<ApplicationUser, GetAllGymsForSearchDto>()
-                .ForMember(dest => dest.Dob, opt => opt.MapFrom(
-                    src => new DateOnly(src.Dob.Year, src.Dob.Month, src.Dob.Day)))
                 .ForMember(dest => dest.GymImages, opt => opt.MapFrom(
                     src => src.GymImages.Select(gi => new GymImageDto { Url = gi }).ToList()))
                 .ForMember(dest => dest.RepresentName, opt => opt.MapFrom(


### PR DESCRIPTION
Eliminated the DateOnly Dob property from GetAllGymsForSearchDto, GetAllGymsDto, and GetGymDetailsDto, as well as related mapping logic in GymMappingProfiles. This streamlines DTOs and mappings by removing unused or unnecessary date of birth information.
