### PR TITLE
#306 Add Freelance PT dashboard statistics endpoint

### DIFF
--- a/FitBridge_API/Controllers/CustomerPurchasedController.cs
+++ b/FitBridge_API/Controllers/CustomerPurchasedController.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc;
 using FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchasedOverallTrainingResults;
 using FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchasedTrainingResultsDetails;
 using FitBridge_Application.Features.CustomerPurchaseds.GetCustomerPurchasedTransactionHistory;
+using FitBridge_Application.Features.CustomerPurchaseds.GetFreelancePtDashboard;
 
 namespace FitBridge_API.Controllers;
 
@@ -214,6 +215,54 @@ public class CustomerPurchasedController(IMediator _mediator) : _BaseApiControll
         return Ok(new BaseResponse<CustomerPurchasedTransactionHistoryDto>(
             StatusCodes.Status200OK.ToString(),
             "Transaction history retrieved successfully",
+            result));
+    }
+
+    /// <summary>
+    /// Get dashboard statistics for Freelance PT
+    /// </summary>
+    /// <returns>Returns comprehensive dashboard statistics including package sales, revenue, and comparisons</returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET /api/v1/customer-purchased/freelance-pt/dashboard
+    ///
+    /// This endpoint provides a comprehensive view of Freelance PT business performance:
+    ///
+    /// **Current Month Statistics:**
+    /// - Total packages sold (new purchases only)
+    /// - Total package extensions
+    /// - Total revenue and profit
+    /// - Number of new customers
+    /// - Number of active customers
+    /// - Number of expired packages
+    ///
+    /// **Previous Month Statistics:**
+    /// - Same metrics as current month for comparison
+    ///
+    /// **Most Popular Packages:**
+    /// - Top 5 packages by total sales (all-time)
+    /// - Includes sales count, extensions, revenue, and profit per package
+    ///
+    /// **Package Revenue Breakdown:**
+    /// - Current month revenue breakdown by package
+    /// - Includes revenue percentage for each package
+    ///
+    /// The endpoint automatically identifies the PT from the authentication token.
+    /// </remarks>
+    /// <response code="200">Dashboard statistics retrieved successfully</response>
+    /// <response code="401">User not authenticated</response>
+    /// <response code="404">PT not found</response>
+    [HttpGet("freelance-pt/dashboard")]
+    [ProducesResponseType(typeof(BaseResponse<FreelancePtDashboardDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetFreelancePtDashboard()
+    {
+        var result = await _mediator.Send(new GetFreelancePtDashboardQuery());
+        return Ok(new BaseResponse<FreelancePtDashboardDto>(
+            StatusCodes.Status200OK.ToString(),
+            "Dashboard statistics retrieved successfully",
             result));
     }
 }

--- a/FitBridge_Application/Dtos/CustomerPurchaseds/FreelancePtDashboardDto.cs
+++ b/FitBridge_Application/Dtos/CustomerPurchaseds/FreelancePtDashboardDto.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace FitBridge_Application.Dtos.CustomerPurchaseds
+{
+    public class FreelancePtDashboardDto
+    {
+        public MonthlyStatisticsDto CurrentMonth { get; set; }
+        public MonthlyStatisticsDto PreviousMonth { get; set; }
+        public int CurrentActiveCustomers { get; set; }
+        public List<PackageSalesStatDto> MostPopularPackages { get; set; } = new List<PackageSalesStatDto>();
+        public List<PackageRevenueDto> PackageRevenueBreakdown { get; set; } = new List<PackageRevenueDto>();
+    }
+}
+

--- a/FitBridge_Application/Dtos/CustomerPurchaseds/MonthlyStatisticsDto.cs
+++ b/FitBridge_Application/Dtos/CustomerPurchaseds/MonthlyStatisticsDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace FitBridge_Application.Dtos.CustomerPurchaseds
+{
+    public class MonthlyStatisticsDto
+    {
+        public int Year { get; set; }
+        public int Month { get; set; }
+        public int TotalPackagesSold { get; set; }
+        public decimal TotalRevenue { get; set; }
+        public decimal TotalProfit { get; set; }
+        public int NewCustomers { get; set; }
+    }
+}
+

--- a/FitBridge_Application/Dtos/CustomerPurchaseds/PackageRevenueDto.cs
+++ b/FitBridge_Application/Dtos/CustomerPurchaseds/PackageRevenueDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace FitBridge_Application.Dtos.CustomerPurchaseds
+{
+    public class PackageRevenueDto
+    {
+        public Guid PackageId { get; set; }
+        public string PackageName { get; set; }
+        public decimal Revenue { get; set; }
+        public decimal Profit { get; set; }
+        public int SalesCount { get; set; }
+        public double RevenuePercentage { get; set; }
+    }
+}
+

--- a/FitBridge_Application/Dtos/CustomerPurchaseds/PackageSalesStatDto.cs
+++ b/FitBridge_Application/Dtos/CustomerPurchaseds/PackageSalesStatDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace FitBridge_Application.Dtos.CustomerPurchaseds
+{
+    public class PackageSalesStatDto
+    {
+        public Guid PackageId { get; set; }
+        public string PackageName { get; set; }
+        public string PackageImageUrl { get; set; }
+        public decimal PackagePrice { get; set; }
+        public int TotalPackagesSold { get; set; }
+        public decimal TotalRevenue { get; set; }
+        public decimal TotalProfit { get; set; }
+    }
+}
+

--- a/FitBridge_Application/Features/CustomerPurchaseds/GetFreelancePtDashboard/GetFreelancePtDashboardQuery.cs
+++ b/FitBridge_Application/Features/CustomerPurchaseds/GetFreelancePtDashboard/GetFreelancePtDashboardQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using FitBridge_Application.Dtos.CustomerPurchaseds;
+
+namespace FitBridge_Application.Features.CustomerPurchaseds.GetFreelancePtDashboard
+{
+    public class GetFreelancePtDashboardQuery : IRequest<FreelancePtDashboardDto>
+    {
+    }
+}
+

--- a/FitBridge_Application/Features/CustomerPurchaseds/GetFreelancePtDashboard/GetFreelancePtDashboardQueryHandler.cs
+++ b/FitBridge_Application/Features/CustomerPurchaseds/GetFreelancePtDashboard/GetFreelancePtDashboardQueryHandler.cs
@@ -1,0 +1,249 @@
+using AutoMapper;
+using FitBridge_Application.Dtos.CustomerPurchaseds;
+using FitBridge_Application.Dtos.FreelancePTPackages;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Interfaces.Services;
+using FitBridge_Application.Interfaces.Utils;
+using FitBridge_Application.Specifications.CustomerPurchaseds.GetCustomerPurchasedForFreelancePt;
+using FitBridge_Application.Specifications.OrderItems.GetOrderItemForFptDashboard;
+using FitBridge_Domain.Entities.Gyms;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Enums.Orders;
+using FitBridge_Domain.Exceptions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FitBridge_Application.Features.CustomerPurchaseds.GetFreelancePtDashboard
+{
+    public class GetFreelancePtDashboardQueryHandler(
+        IUnitOfWork unitOfWork,
+        IUserUtil userUtil,
+        IHttpContextAccessor httpContextAccessor,
+        ITransactionService transactionService,
+        ILogger<GetFreelancePtDashboardQueryHandler> _logger,
+        IMapper mapper)
+        : IRequestHandler<GetFreelancePtDashboardQuery, FreelancePtDashboardDto>
+    {
+        public async Task<FreelancePtDashboardDto> Handle(
+            GetFreelancePtDashboardQuery request,
+            CancellationToken cancellationToken)
+        {
+            var ptId = userUtil.GetAccountId(httpContextAccessor.HttpContext);
+            if (ptId == null)
+            {
+                throw new NotFoundException("PT ID not found");
+            }
+            string timeZoneId = Environment.OSVersion.Platform == PlatformID.Win32NT 
+            ? "SE Asia Standard Time" 
+            : "Asia/Ho_Chi_Minh";
+    
+            var localTimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            var utcNow = DateTime.UtcNow;
+            var localNow = TimeZoneInfo.ConvertTimeFromUtc(utcNow, localTimeZone);
+            _logger.LogInformation("Local now: {LocalNow}", localNow);
+            
+            var currentDate = localNow;
+            var currentMonthStart = new DateTime(currentDate.Year, currentDate.Month, 1);
+            var previousMonthStart = currentMonthStart.AddMonths(-1);
+            var previousMonthEnd = currentMonthStart.AddSeconds(-2);
+
+            var activeCustomers = await unitOfWork.Repository<CustomerPurchased>().CountAsync(new GetCustomerPurchasedForFreelancePtSpec(ptId.Value, new GetCustomerPurchasedForFreelancePtParams { DoApplyPaging = false }));
+
+            // Get all OrderItems for this PT's packages with necessary includes
+            var allOrderItems = await unitOfWork.Repository<OrderItem>()
+                .GetAllWithSpecificationAsync(new GetOrderItemForFptDashboardSpec(ptId.Value));
+            // Calculate current month statistics
+            var currentMonthStats = await CalculateMonthlyStatistics(
+                allOrderItems.ToList(),
+                currentMonthStart,
+                currentDate,
+                ptId.Value);
+
+            // Calculate previous month statistics
+            var previousMonthStats = await CalculateMonthlyStatistics(
+                allOrderItems.ToList(),
+                previousMonthStart,
+                previousMonthEnd,
+                ptId.Value);
+
+            // Get most popular packages (all-time, top 5)
+            var mostPopularPackages = await GetMostPopularPackages(allOrderItems.ToList(), ptId.Value);
+
+            // Get package revenue breakdown (current month)
+            var packageRevenueBreakdown = await GetPackageRevenueBreakdown(
+                allOrderItems.Where(oi => oi.UpdatedAt >= currentMonthStart).ToList(),
+                ptId.Value);
+
+            return new FreelancePtDashboardDto
+            {
+                CurrentMonth = currentMonthStats,
+                PreviousMonth = previousMonthStats,
+                MostPopularPackages = mostPopularPackages,
+                PackageRevenueBreakdown = packageRevenueBreakdown,
+                CurrentActiveCustomers = activeCustomers,
+            };
+        }
+
+        private async Task<MonthlyStatisticsDto> CalculateMonthlyStatistics(
+            List<OrderItem> allOrderItems,
+            DateTime periodStart,
+            DateTime periodEnd,
+            Guid ptId)
+        {
+            var periodOrderItems = allOrderItems
+                .Where(oi => oi.UpdatedAt >= periodStart && oi.UpdatedAt <= periodEnd)
+                .ToList();
+
+            var numOfPurchases = periodOrderItems
+                .Count(oi => oi.CustomerPurchased != null);
+            // Calculate total revenue
+            decimal totalRevenue = 0;
+            decimal totalProfit = 0;
+
+            foreach (var orderItem in periodOrderItems)
+            {
+                var itemRevenue = orderItem.Price * orderItem.Quantity;
+                totalRevenue += itemRevenue;
+
+                // Calculate profit using the TransactionService method
+                var profit = await transactionService.CalculateMerchantProfit(orderItem, orderItem.Order?.Coupon);
+                totalProfit += profit;
+            }
+
+            // Count new customers (customers who made their first purchase in this period)
+            var totalCustomerIds = allOrderItems.GroupBy(oi => oi.CustomerPurchased.CustomerId).Select(group => new
+            {
+                CustomerId = group.Key,
+                GroupCount = group.Count()
+            }).ToList();
+            var currentCustomerIds = periodOrderItems.Select(oi => oi.CustomerPurchased.CustomerId).Distinct().ToList();
+            var newCustomers = totalCustomerIds.Where(x => currentCustomerIds.Contains(x.CustomerId) && x.GroupCount == 1).Count();
+        
+
+            return new MonthlyStatisticsDto
+            {
+                Year = periodStart.Year,
+                Month = periodStart.Month,
+                TotalPackagesSold = numOfPurchases,
+                TotalRevenue = totalRevenue,
+                TotalProfit = totalProfit,
+                NewCustomers = newCustomers
+            };
+        }
+
+        private async Task<List<PackageSalesStatDto>> GetMostPopularPackages(
+            List<OrderItem> allOrderItems,
+            Guid ptId)
+        {
+            // Group by package and calculate statistics
+            var packageStats = allOrderItems
+                .GroupBy(oi => oi.FreelancePTPackageId)
+                .Select(g => new
+                {
+                    PackageId = g.Key.Value,
+                    Package = g.First().FreelancePTPackage,
+                    OrderItems = g.ToList()
+                })
+                .ToList();
+
+            var result = new List<PackageSalesStatDto>();
+
+            foreach (var packageGroup in packageStats)
+            {
+                var numOfPackagesSold = packageGroup.OrderItems
+                    .Count(oi => oi.CustomerPurchased != null);
+
+                decimal totalRevenue = 0;
+                decimal totalProfit = 0;
+
+                foreach (var orderItem in packageGroup.OrderItems)
+                {
+                    totalRevenue += orderItem.Price * orderItem.Quantity;
+                    var profit = await transactionService.CalculateMerchantProfit(orderItem, orderItem.Order?.Coupon);
+                    totalProfit += profit;
+                }
+
+                result.Add(new PackageSalesStatDto
+                {
+                    PackageId = packageGroup.PackageId,
+                    PackageName = packageGroup.Package.Name,
+                    PackageImageUrl = packageGroup.Package.ImageUrl,
+                    PackagePrice = packageGroup.Package.Price,
+                    TotalPackagesSold = numOfPackagesSold,
+                    TotalRevenue = totalRevenue,
+                    TotalProfit = totalProfit
+                });
+            }
+
+            // Return top 3 by total sales
+            return result.OrderByDescending(p => p.TotalPackagesSold).Take(3).ToList();
+        }
+
+        private async Task<List<PackageRevenueDto>> GetPackageRevenueBreakdown(
+            List<OrderItem> periodOrderItems,
+            Guid ptId)
+        {
+            if (!periodOrderItems.Any())
+            {
+                return new List<PackageRevenueDto>();
+            }
+
+            // Calculate total revenue for percentage calculation
+            decimal totalPeriodRevenue = 0;
+            var packageGroups = periodOrderItems
+                .GroupBy(oi => oi.FreelancePTPackageId)
+                .ToList();
+
+            // First pass: calculate total revenue
+            foreach (var group in packageGroups)
+            {
+                totalPeriodRevenue += group.Sum(oi => oi.Price * oi.Quantity);
+            }
+
+            var result = new List<PackageRevenueDto>();
+
+            // Second pass: create breakdown with percentages
+            foreach (var packageGroup in packageGroups)
+            {
+                var packageOrderItems = packageGroup.ToList();
+                var package = packageOrderItems.First().FreelancePTPackage;
+
+                decimal revenue = 0;
+                decimal profit = 0;
+
+                foreach (var orderItem in packageOrderItems)
+                {
+                    revenue += orderItem.Price * orderItem.Quantity;
+                    var itemProfit = await transactionService.CalculateMerchantProfit(orderItem, orderItem.Order?.Coupon);
+                    profit += itemProfit;
+                }
+
+                var revenuePercentage = totalPeriodRevenue > 0 
+                    ? (double)(revenue / totalPeriodRevenue * 100) 
+                    : 0;
+
+                result.Add(new PackageRevenueDto
+                {
+                    PackageId = packageGroup.Key.Value,
+                    PackageName = package.Name,
+                    Revenue = revenue,
+                    Profit = profit,
+                    SalesCount = packageOrderItems.Count,
+                    RevenuePercentage = Math.Round(revenuePercentage, 1)
+                });
+            }
+
+            // Sort by revenue descending
+            return result.OrderByDescending(p => p.Revenue).ToList();
+        }
+    }
+}
+

--- a/FitBridge_Application/Services/TransactionsService.cs
+++ b/FitBridge_Application/Services/TransactionsService.cs
@@ -92,6 +92,7 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
         customerPurchasedToExtend.ExpirationDate = customerPurchasedToExtend.ExpirationDate.AddDays(orderItemToExtend.GymCourse.Duration * orderItemToExtend.Quantity);
         var profitDistributionDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(defaultProfitDistributionDays); // Profit distribute planned date is the day after the expiration date
         orderItemToExtend.ProfitDistributePlannedDate = profitDistributionDate;
+        orderItemToExtend.UpdatedAt = DateTime.UtcNow;
         transactionToExtend.Order.Status = OrderStatus.Finished;
         var walletToUpdate = await _unitOfWork.Repository<Wallet>().GetByIdAsync(orderItemToExtend.GymCourse.GymOwnerId);
         if (walletToUpdate == null)
@@ -276,6 +277,7 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
                 AvailableSessions = orderItem.Quantity * numOfSession,
                 ExpirationDate = expirationDate,
             };
+            orderItem.UpdatedAt = DateTime.UtcNow;
             var walletToUpdate = await _unitOfWork.Repository<Wallet>().GetByIdAsync(orderItem.FreelancePTPackage.PtId);
             if (walletToUpdate == null)
             {
@@ -369,6 +371,7 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
                     AvailableSessions = orderItem.Quantity * numOfSession,
                     ExpirationDate = expirationDate,
                 };
+                orderItem.UpdatedAt = DateTime.UtcNow;
                 if (orderItem.GymPtId != null)
                 {
                     await _scheduleJobServices.ScheduleAutoUpdatePTCurrentCourseJob(orderItem.Id, expirationDate);
@@ -413,6 +416,7 @@ public class TransactionsService(IUnitOfWork _unitOfWork, ILogger<TransactionsSe
         var orderItemToExtend = transactionToExtend.Order.OrderItems.First();
         var customerPurchasedToExtend = transactionToExtend.Order.CustomerPurchasedToExtend;
         orderItemToExtend.CustomerPurchasedId = customerPurchasedToExtend.Id;
+        orderItemToExtend.UpdatedAt = DateTime.UtcNow;
 
         var numOfSession = orderItemToExtend.FreelancePTPackage.NumOfSessions;
         customerPurchasedToExtend.AvailableSessions += orderItemToExtend.Quantity * numOfSession;

--- a/FitBridge_Application/Specifications/Bookings/GetCustomerBookings/GetCustomerBookingsParams.cs
+++ b/FitBridge_Application/Specifications/Bookings/GetCustomerBookings/GetCustomerBookingsParams.cs
@@ -6,7 +6,6 @@ namespace FitBridge_Application.Specifications.Bookings.GetCustomerBookings;
 public class GetCustomerBookingsParams : BaseParams
 {
     public Guid CustomerId { get; set; }
-    [Required]
     public DateOnly? Date { get; set; }
     public Guid? CustomerPurchasedId { get; set; }
 }

--- a/FitBridge_Application/Specifications/OrderItems/GetOrderItemForFptDashboard/GetOrderItemForFptDashboardSpec.cs
+++ b/FitBridge_Application/Specifications/OrderItems/GetOrderItemForFptDashboard/GetOrderItemForFptDashboardSpec.cs
@@ -1,0 +1,20 @@
+using System;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Enums.Orders;
+
+namespace FitBridge_Application.Specifications.OrderItems.GetOrderItemForFptDashboard;
+
+public class GetOrderItemForFptDashboardSpec : BaseSpecification<OrderItem>
+{
+    public GetOrderItemForFptDashboardSpec(Guid ptId) : base(x => x.IsEnabled
+        && x.FreelancePTPackageId != null
+        && x.FreelancePTPackage.PtId == ptId
+        && x.CustomerPurchased != null
+        && x.Order.Status == OrderStatus.Finished)
+    {
+        AddInclude(x => x.FreelancePTPackage);
+        AddInclude(x => x.CustomerPurchased);
+        AddInclude(x => x.Order);
+        AddInclude(x => x.Order.Coupon);
+    }
+}


### PR DESCRIPTION
Introduces a new API endpoint to retrieve comprehensive dashboard statistics for Freelance PTs, including current and previous month metrics, most popular packages, and package revenue breakdown. Adds related DTOs, query/handler, and supporting specifications. Also updates TransactionsService to set UpdatedAt on relevant order item operations and removes a redundant attribute in GetCustomerBookingsParams.