### PR TITLE
Rename WithdrawDate to TransactionDate and update handlers

### DIFF
--- a/FitBridge_Application/Dtos/Dashboards/AvailableBalanceTransactionDto.cs
+++ b/FitBridge_Application/Dtos/Dashboards/AvailableBalanceTransactionDto.cs
@@ -8,7 +8,7 @@
 
         public DateOnly? ActualDistributionDate { get; set; }
 
-        public DateTime? WithdrawDate { get; set; }
+        public DateTime? TransactionDate { get; set; }
 
         public string TransactionType { get; set; }
 

--- a/FitBridge_Application/Features/Dashboards/GetAvailableBalanceDetail/GetAvailableBalanceDetailQueryHandler.cs
+++ b/FitBridge_Application/Features/Dashboards/GetAvailableBalanceDetail/GetAvailableBalanceDetailQueryHandler.cs
@@ -66,8 +66,7 @@ namespace FitBridge_Application.Features.Dashboards.GetAvailableBalanceDetail
                     TotalProfit = isWithdrawal ? transaction.Amount * -1 : transaction.Amount,
                     TransactionType = transaction.TransactionType.ToString(),
                     ActualDistributionDate = isWithdrawal ? null : transaction.OrderItem!.ProfitDistributeActualDate,
-                    WithdrawDate = isWithdrawal && transaction.WithdrawalRequestId != null
-                                   ? transaction.CreatedAt : null, // by the time admin approved
+                    TransactionDate = transaction.CreatedAt,  // by the time admin approved
                     WithdrawalRequestId = isWithdrawal ? transaction.WithdrawalRequestId : null,
                     Description = transaction.Description
                 };

--- a/FitBridge_Application/Features/Payments/ApproveWithdrawalRequest/ApproveWithdrawalRequestCommandHandler.cs
+++ b/FitBridge_Application/Features/Payments/ApproveWithdrawalRequest/ApproveWithdrawalRequestCommandHandler.cs
@@ -28,7 +28,7 @@ namespace FitBridge_Application.Features.Payments.ApproveWithdrawalRequest
                     $"{withdrawalRequest.Status}. Only pending requests can be approved.");
             }
 
-            UpdateWithdrawalRequest(withdrawalRequest);
+            UpdateWithdrawalRequest(withdrawalRequest, request.ImageUrl);
 
             var updatedWallet = await UpdateUserWallet(withdrawalRequest);
             await InsertTransactionAsync(withdrawalRequest, updatedWallet);
@@ -95,9 +95,10 @@ namespace FitBridge_Application.Features.Payments.ApproveWithdrawalRequest
             await notificationService.NotifyUsers(message);
         }
 
-        private void UpdateWithdrawalRequest(WithdrawalRequest withdrawalRequest)
+        private void UpdateWithdrawalRequest(WithdrawalRequest withdrawalRequest, string imgUrls)
         {
             withdrawalRequest.Status = WithdrawalRequestStatus.AdminApproved;
+            withdrawalRequest.ImageUrl = imgUrls;
             withdrawalRequest.IsUserApproved = false;
             withdrawalRequest.UpdatedAt = DateTime.UtcNow;
             unitOfWork.Repository<WithdrawalRequest>().Update(withdrawalRequest);


### PR DESCRIPTION
Renamed the WithdrawDate property to TransactionDate in AvailableBalanceTransactionDto and updated all relevant usages in GetAvailableBalanceDetailQueryHandler. Modified ApproveWithdrawalRequestCommandHandler to pass and set ImageUrl when updating withdrawal requests.
