### PR TITLE
#306 Add customer order history endpoint and related DTOs

### DIFF
--- a/FitBridge_Application/Dtos/Orders/CouponSummaryDto.cs
+++ b/FitBridge_Application/Dtos/Orders/CouponSummaryDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Orders
+{
+    public class CouponSummaryDto
+    {
+        public Guid CouponId { get; set; }
+        public required string CouponCode { get; set; }
+        public double DiscountPercent { get; set; }
+        public decimal MaxDiscount { get; set; }
+    }
+}
+

--- a/FitBridge_Application/Dtos/Orders/CustomerOrderHistoryDto.cs
+++ b/FitBridge_Application/Dtos/Orders/CustomerOrderHistoryDto.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace FitBridge_Application.Dtos.Orders
+{
+    public class CustomerOrderHistoryDto
+    {
+        public Guid OrderId { get; set; }
+        public required string OrderStatus { get; set; }
+        public decimal SubTotalPrice { get; set; }
+        public decimal TotalAmount { get; set; }
+        public decimal DiscountAmount { get; set; }
+        public CouponSummaryDto? Coupon { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public List<OrderItemSummaryDto> Items { get; set; } = new();
+        public List<CustomerTransactionDetailDto> Transactions { get; set; } = new();
+    }
+}
+

--- a/FitBridge_Application/Dtos/Orders/CustomerTransactionDetailDto.cs
+++ b/FitBridge_Application/Dtos/Orders/CustomerTransactionDetailDto.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Orders
+{
+    public class CustomerTransactionDetailDto
+    {
+        public Guid TransactionId { get; set; }
+        public long OrderCode { get; set; }
+        public string TransactionType { get; set; }
+        public string Status { get; set; }
+        public decimal Amount { get; set; }
+        public string Description { get; set; }
+        public string PaymentMethodName { get; set; }
+        public DateTime TransactionDate { get; set; }
+    }
+}
+

--- a/FitBridge_Application/Dtos/Orders/OrderItemSummaryDto.cs
+++ b/FitBridge_Application/Dtos/Orders/OrderItemSummaryDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace FitBridge_Application.Dtos.Orders
+{
+    public class OrderItemSummaryDto
+    {
+        public Guid OrderItemId { get; set; }
+        public string ItemName { get; set; }
+        public Guid? FreelancePTPackageId { get; set; }
+        public Guid? GymCourseId { get; set; }
+        public string ImageUrl { get; set; }
+        public decimal Price { get; set; }
+        public int Quantity { get; set; }
+    }
+}
+

--- a/FitBridge_Application/Features/Orders/GetCustomerOrderHistory/GetCustomerOrderHistoryQuery.cs
+++ b/FitBridge_Application/Features/Orders/GetCustomerOrderHistory/GetCustomerOrderHistoryQuery.cs
@@ -1,0 +1,14 @@
+using MediatR;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.Orders;
+using FitBridge_Application.Specifications.Orders.GetCustomerOrderHistory;
+
+namespace FitBridge_Application.Features.Orders.GetCustomerOrderHistory
+{
+    public class GetCustomerOrderHistoryQuery(GetCustomerOrderHistoryParams parameters) 
+        : IRequest<PagingResultDto<CustomerOrderHistoryDto>>
+    {
+        public GetCustomerOrderHistoryParams Params { get; set; } = parameters;
+    }
+}
+

--- a/FitBridge_Application/Features/Orders/GetCustomerOrderHistory/GetCustomerOrderHistoryQueryHandler.cs
+++ b/FitBridge_Application/Features/Orders/GetCustomerOrderHistory/GetCustomerOrderHistoryQueryHandler.cs
@@ -1,0 +1,104 @@
+using AutoMapper;
+using FitBridge_Application.Dtos;
+using FitBridge_Application.Dtos.Orders;
+using FitBridge_Application.Interfaces.Repositories;
+using FitBridge_Application.Interfaces.Utils;
+using FitBridge_Application.Specifications.Orders.GetCustomerOrderHistory;
+using FitBridge_Domain.Entities.Identity;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Enums.Orders;
+using FitBridge_Domain.Exceptions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+
+namespace FitBridge_Application.Features.Orders.GetCustomerOrderHistory
+{
+    public class GetCustomerOrderHistoryQueryHandler(
+        IUnitOfWork unitOfWork,
+        IUserUtil userUtil,
+        IHttpContextAccessor httpContextAccessor,
+        IMapper _mapper)
+        : IRequestHandler<GetCustomerOrderHistoryQuery, PagingResultDto<CustomerOrderHistoryDto>>
+    {
+        public async Task<PagingResultDto<CustomerOrderHistoryDto>> Handle(
+            GetCustomerOrderHistoryQuery request,
+            CancellationToken cancellationToken)
+        {
+            var customerId = userUtil.GetAccountId(httpContextAccessor.HttpContext);
+            if (customerId == null)
+            {
+                throw new NotFoundException(nameof(ApplicationUser));
+            }
+
+            var targetTransactionTypes = new[]
+            {
+                TransactionType.GymCourse,
+                TransactionType.FreelancePTPackage,
+                TransactionType.ExtendFreelancePTPackage,
+                TransactionType.ExtendCourse
+            };
+
+            var spec = new GetCustomerOrderHistorySpec(request.Params, customerId.Value);
+            
+            var orders = await unitOfWork.Repository<Order>()
+                .GetAllWithSpecificationAsync(spec);
+            
+            var totalCount = await unitOfWork.Repository<Order>().CountAsync(spec);
+
+            var result = new List<CustomerOrderHistoryDto>();
+
+            foreach (var order in orders)
+            {
+                var discountAmount = order.SubTotalPrice - order.TotalAmount;
+                
+                var orderDto = _mapper.Map<CustomerOrderHistoryDto>(order);
+                orderDto.DiscountAmount = discountAmount;
+
+                if (order.Coupon != null)
+                {
+                    orderDto.Coupon = _mapper.Map<CouponSummaryDto>(order.Coupon);
+                }
+
+                foreach (var orderItem in order.OrderItems)
+                {
+                    if (orderItem.FreelancePTPackageId != null || orderItem.GymCourseId != null)
+                    {
+                        var itemDto = _mapper.Map<OrderItemSummaryDto>(orderItem);
+
+                        if (orderItem.FreelancePTPackageId != null && orderItem.FreelancePTPackage != null)
+                        {
+                            itemDto.ItemName = orderItem.FreelancePTPackage.Name;
+                            itemDto.ImageUrl = orderItem.FreelancePTPackage.ImageUrl ?? string.Empty;
+                        }
+                        else if (orderItem.GymCourseId != null && orderItem.GymCourse != null)
+                        {
+                            itemDto.ItemName = orderItem.GymCourse.Name;
+                            itemDto.ImageUrl = orderItem.GymCourse.ImageUrl ?? string.Empty;
+                        }
+
+                        orderDto.Items.Add(itemDto);
+                    }
+                }
+
+                var relevantTransactions = order.Transactions
+                    .Where(t => targetTransactionTypes.Contains(t.TransactionType))
+                    .ToList();
+
+                foreach (var transaction in relevantTransactions)
+                {
+                    var transactionDto = _mapper.Map<CustomerTransactionDetailDto>(transaction);
+                    orderDto.Transactions.Add(transactionDto);
+                }
+
+                orderDto.Transactions = orderDto.Transactions
+                    .OrderByDescending(t => t.TransactionDate)
+                    .ToList();
+
+                result.Add(orderDto);
+            }
+
+            return new PagingResultDto<CustomerOrderHistoryDto>(totalCount, result);
+        }
+    }
+}
+

--- a/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/OrderItemMappingProfile.cs
@@ -2,6 +2,7 @@ using System;
 using AutoMapper;
 using FitBridge_Application.Dtos.Dashboards;
 using FitBridge_Application.Dtos.OrderItems;
+using FitBridge_Application.Dtos.Orders;
 using FitBridge_Domain.Entities.Orders;
 
 namespace FitBridge_Application.MappingProfiles;
@@ -24,5 +25,12 @@ public class OrderItemMappingProfile : Profile
         CreateMap<OrderItem, OrderItemForCourseOrderResponseDto>()
         .ForMember(dest => dest.ProductName, opt => opt.MapFrom(src => src.GymCourse.Name))
         .ForMember(dest => dest.FreelancePTPackage, opt => opt.MapFrom(src => src.FreelancePTPackage));
+
+        CreateMap<OrderItem, OrderItemSummaryDto>()
+        .ForMember(dest => dest.OrderItemId, opt => opt.MapFrom(src => src.Id))
+        .ForMember(dest => dest.FreelancePTPackageId, opt => opt.MapFrom(src => src.FreelancePTPackageId))
+        .ForMember(dest => dest.GymCourseId, opt => opt.MapFrom(src => src.GymCourseId))
+        .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.Price))
+        .ForMember(dest => dest.Quantity, opt => opt.MapFrom(src => src.Quantity));
     }
 }

--- a/FitBridge_Application/MappingProfiles/OrderMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/OrderMappingProfile.cs
@@ -38,5 +38,11 @@ public class OrderMappingProfile : Profile
         .ForMember(dest => dest.CouponId, opt => opt.MapFrom(src => src.CouponId))
         .ForMember(dest => dest.DiscountPercent, opt => opt.MapFrom(src => src.Coupon != null ? src.Coupon.DiscountPercent : 0))
         .ForMember(dest => dest.OrderItems, opt => opt.MapFrom(src => src.OrderItems));
+        CreateMap<Order, CustomerOrderHistoryDto>()
+        .ForMember(dest => dest.OrderId, opt => opt.MapFrom(src => src.Id))
+        .ForMember(dest => dest.OrderStatus, opt => opt.MapFrom(src => src.Status))
+        .ForMember(dest => dest.SubTotalPrice, opt => opt.MapFrom(src => src.SubTotalPrice))
+        .ForMember(dest => dest.TotalAmount, opt => opt.MapFrom(src => src.TotalAmount))
+        .ForMember(dest => dest.CreatedAt, opt => opt.MapFrom(src => src.CreatedAt));
     }
 }

--- a/FitBridge_Application/MappingProfiles/TransactionMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/TransactionMappingProfile.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using FitBridge_Application.Dtos.Orders;
 using FitBridge_Application.Dtos.Transactions;
 using FitBridge_Domain.Entities.Orders;
 using FitBridge_Domain.Enums.Orders;
@@ -30,6 +31,15 @@ namespace FitBridge_Application.MappingProfiles
                 .ForMember(x => x.OrderId, opt => opt.MapFrom(y => y.OrderId))
                 .ForMember(x => x.WalletId, opt => opt.MapFrom(y => y.WalletId))
                 .ForMember(x => x.WithdrawalRequestId, opt => opt.MapFrom(y => y.WithdrawalRequestId));
+            CreateMap<Transaction, CustomerTransactionDetailDto>()
+                .ForMember(dest => dest.TransactionId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(dest => dest.OrderCode, opt => opt.MapFrom(src => src.OrderCode))
+                .ForMember(dest => dest.TransactionType, opt => opt.MapFrom(src => src.TransactionType))
+                .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
+                .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount))
+                .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+                .ForMember(dest => dest.PaymentMethodName, opt => opt.MapFrom(src => src.PaymentMethod.MethodType.ToString()))
+                .ForMember(dest => dest.TransactionDate, opt => opt.MapFrom(src => src.CreatedAt));
         }
     }
 }

--- a/FitBridge_Application/MappingProfiles/VoucherMappingProfile.cs
+++ b/FitBridge_Application/MappingProfiles/VoucherMappingProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using FitBridge_Application.Dtos.Coupons;
+using FitBridge_Application.Dtos.Orders;
 using FitBridge_Domain.Entities.Orders;
 
 namespace FitBridge_Application.MappingProfiles
@@ -10,6 +11,11 @@ namespace FitBridge_Application.MappingProfiles
         {
             CreateMap<Coupon, CreateNewCouponDto>();
             CreateProjection<Coupon, GetCouponsDto>();
+            CreateMap<Coupon, CouponSummaryDto>()
+            .ForMember(dest => dest.CouponId, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.CouponCode, opt => opt.MapFrom(src => src.CouponCode))
+            .ForMember(dest => dest.DiscountPercent, opt => opt.MapFrom(src => src.DiscountPercent))
+            .ForMember(dest => dest.MaxDiscount, opt => opt.MapFrom(src => src.MaxDiscount));
         }
     }
 }

--- a/FitBridge_Application/Specifications/Orders/GetCustomerOrderHistory/GetCustomerOrderHistoryParams.cs
+++ b/FitBridge_Application/Specifications/Orders/GetCustomerOrderHistory/GetCustomerOrderHistoryParams.cs
@@ -1,0 +1,12 @@
+using System;
+using FitBridge_Domain.Enums.Orders;
+
+namespace FitBridge_Application.Specifications.Orders.GetCustomerOrderHistory
+{
+    public class GetCustomerOrderHistoryParams : BaseParams
+    {
+        public Guid? OrderId { get; set; }
+        public OrderStatus? OrderStatus { get; set; }
+    }
+}
+

--- a/FitBridge_Application/Specifications/Orders/GetCustomerOrderHistory/GetCustomerOrderHistorySpec.cs
+++ b/FitBridge_Application/Specifications/Orders/GetCustomerOrderHistory/GetCustomerOrderHistorySpec.cs
@@ -1,0 +1,68 @@
+using FitBridge_Application.Commons.Utils;
+using FitBridge_Application.Dtos.Orders;
+using FitBridge_Domain.Entities.Orders;
+using FitBridge_Domain.Enums.Orders;
+using System;
+using System.Linq;
+
+namespace FitBridge_Application.Specifications.Orders.GetCustomerOrderHistory
+{
+    public class GetCustomerOrderHistorySpec : BaseSpecification<Order>
+    {
+        public GetCustomerOrderHistorySpec(
+            GetCustomerOrderHistoryParams parameters,
+            Guid customerId)
+            : base(x =>
+                x.IsEnabled
+                && x.AccountId == customerId
+                && x.Transactions.Any(t =>
+                    t.TransactionType == TransactionType.GymCourse
+                    || t.TransactionType == TransactionType.FreelancePTPackage
+                    || t.TransactionType == TransactionType.ExtendFreelancePTPackage
+                    || t.TransactionType == TransactionType.ExtendCourse)
+                && (parameters.OrderId == null || x.Id == parameters.OrderId)
+                && (parameters.OrderStatus == null || x.Status == parameters.OrderStatus.Value))
+        {
+            AddInclude(x => x.OrderItems);
+            AddInclude("OrderItems.FreelancePTPackage");
+            AddInclude("OrderItems.GymCourse");
+            AddInclude(x => x.Transactions);
+            AddInclude("Transactions.PaymentMethod");
+            AddInclude(x => x.Coupon);
+
+            switch (StringCapitalizationConverter.ToUpperFirstChar(parameters.SortBy))
+            {
+                case nameof(CustomerOrderHistoryDto.TotalAmount):
+                    if (parameters.SortOrder == "asc")
+                        AddOrderBy(x => x.TotalAmount);
+                    else
+                        AddOrderByDesc(x => x.TotalAmount);
+                    break;
+
+                case nameof(CustomerOrderHistoryDto.OrderStatus):
+                    if (parameters.SortOrder == "asc")
+                        AddOrderBy(x => x.Status);
+                    else
+                        AddOrderByDesc(x => x.Status);
+                    break;
+
+                case nameof(CustomerOrderHistoryDto.CreatedAt):
+                    if (parameters.SortOrder == "asc")
+                        AddOrderBy(x => x.CreatedAt);
+                    else
+                        AddOrderByDesc(x => x.CreatedAt);
+                    break;
+
+                default:
+                    AddOrderByDesc(x => x.CreatedAt);
+                    break;
+            }
+
+            if (parameters.DoApplyPaging)
+            {
+                AddPaging((parameters.Page - 1) * parameters.Size, parameters.Size);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Introduces a new API endpoint to retrieve authenticated customers' order history for training packages, including filtering and pagination. Adds supporting DTOs (CustomerOrderHistoryDto, OrderItemSummaryDto, CustomerTransactionDetailDto, CouponSummaryDto), query/handler/specification classes, and updates AutoMapper profiles for mapping. This enables clients to fetch detailed order and transaction history for training package purchases.